### PR TITLE
Frame-By-Frame Video View

### DIFF
--- a/ImageViewer.sln
+++ b/ImageViewer.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29827.131
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageViewer", "ImageViewer\ImageViewer.csproj", "{C8C0F86C-7D7C-4C3B-812D-0B0354E803EA}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ImageViewerNative", "ImageViewerNative\ImageViewerNative.vcxproj", "{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,22 @@ Global
 		{C8C0F86C-7D7C-4C3B-812D-0B0354E803EA}.Release|x86.ActiveCfg = Release|x86
 		{C8C0F86C-7D7C-4C3B-812D-0B0354E803EA}.Release|x86.Build.0 = Release|x86
 		{C8C0F86C-7D7C-4C3B-812D-0B0354E803EA}.Release|x86.Deploy.0 = Release|x86
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|ARM.ActiveCfg = Debug|ARM
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|ARM.Build.0 = Debug|ARM
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|ARM64.Build.0 = Debug|ARM64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|x64.ActiveCfg = Debug|x64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|x64.Build.0 = Debug|x64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|x86.ActiveCfg = Debug|Win32
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Debug|x86.Build.0 = Debug|Win32
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|ARM.ActiveCfg = Release|ARM
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|ARM.Build.0 = Release|ARM
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|ARM64.ActiveCfg = Release|ARM64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|ARM64.Build.0 = Release|ARM64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|x64.ActiveCfg = Release|x64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|x64.Build.0 = Release|x64
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|x86.ActiveCfg = Release|Win32
+		{EC7BC29A-FBBA-4A3B-ABCB-9BBA4DC76EE3}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ImageViewer/Controls/ImageViewer.xaml.cs
+++ b/ImageViewer/Controls/ImageViewer.xaml.cs
@@ -69,7 +69,7 @@ namespace ImageViewer.Controls
             var oldImage = e.OldValue as IImage;
             oldImage?.Dispose();
             var newImage = e.NewValue as IImage;
-            viewer.OnImageChnaged();
+            viewer.OnImageChanged();
         }
 
         private static void OnGridLinesColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -498,7 +498,7 @@ namespace ImageViewer.Controls
             }
         }
 
-        private void OnImageChnaged()
+        private void OnImageChanged()
         {
             if (Image != null)
             {

--- a/ImageViewer/Extensions.cs
+++ b/ImageViewer/Extensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Graphics;
+using Windows.Graphics.Imaging;
+
+namespace ImageViewer
+{
+    static class SizeExtensions
+    {
+        public static SizeInt32 ToSizeInt32(this BitmapSize size)
+        {
+            return new SizeInt32() { Width = (int)size.Width, Height = (int)size.Height };
+        }
+    }
+}

--- a/ImageViewer/FrameExtractor.cs
+++ b/ImageViewer/FrameExtractor.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Graphics;
+using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
+using Windows.Graphics.Imaging;
+using Windows.Media.Core;
+using Windows.Media.Playback;
+using Windows.Storage.Streams;
+using Windows.UI.Composition;
+using Windows.UI.Xaml.Controls.Maps;
+using WinRTInteropTools;
+
+namespace ImageViewer
+{
+    /*
+    class FrameExtractor
+    {
+        private MediaPlayer _player;
+        private SizeInt32 _size;
+        private CompositionGraphicsDevice _compGraphics;
+        private Direct3D11Device _device;
+        private Direct3D11Texture2D _scratchTexture;
+
+        private bool _ended = false;
+        private TaskCompletionSource<bool> _currentFrameSource = null;
+        private TaskCompletionSource<bool> _endedSource;
+
+        public FrameExtractor(MediaSource source, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
+        {
+            var item = new MediaPlaybackItem(source);
+            var bitmapSize = new BitmapSize() { Width = 0, Height = 0 };
+            foreach (var track in item.VideoTracks)
+            {
+                var properties = track.GetEncodingProperties();
+                if (bitmapSize.Width < properties.Width && bitmapSize.Height < properties.Height)
+                {
+                    bitmapSize.Width = properties.Width;
+                    bitmapSize.Height = properties.Height;
+                }
+            }
+            _size = new SizeInt32() { Width = (int)bitmapSize.Width, Height = (int)bitmapSize.Height };
+
+            _compGraphics = compGraphics;
+            _device = device;
+            _endedSource = new TaskCompletionSource<bool>();
+
+            var description = new Direct3D11Texture2DDescription();
+            description.Base = new Direct3DSurfaceDescription();
+            description.Base.Format = DirectXPixelFormat.B8G8R8A8UIntNormalized;
+            description.Base.Width = _size.Width;
+            description.Base.Height = _size.Height;
+            description.Base.MultisampleDescription = new Direct3DMultisampleDescription();
+            description.Base.MultisampleDescription.Count = 1;
+            description.Base.MultisampleDescription.Quality = 0;
+            description.ArraySize = 1;
+            description.BindFlags = Direct3DBindings.ShaderResource;
+            description.CpuAccessFlags = 0;
+            description.MiscFlags = 0;
+            description.MipLevels = 1;
+            _scratchTexture = device.CreateTexture2D(description);
+
+            _player = new MediaPlayer();
+            _player.IsVideoFrameServerEnabled = true;
+            _player.AutoPlay = false;
+            _player.VideoFrameAvailable += OnVideoFrameAvailable;
+            _player.MediaEnded += OnMediaEnded;
+            _player.Media
+            _player.Source = item;
+            _player.Pause();
+        }
+
+        public async Task<VideoFrame> TryGetNextFrameAsync()
+        {
+            if (_ended)
+            {
+                return null;
+            }
+
+            //global::System.Diagnostics.Debug.WriteLine("Get Frame Start");
+
+            global::System.Diagnostics.Debug.Assert(_currentFrameSource == null);
+            _currentFrameSource = new TaskCompletionSource<bool>();
+            _player.StepForwardOneFrame();
+
+            VideoFrame result = null;
+            var task = await Task.WhenAny(_currentFrameSource.Task, _endedSource.Task);
+            if (task == _currentFrameSource.Task && task.Result)
+            {
+                _player.CopyFrameToVideoSurface(_scratchTexture);
+                var surface = _compGraphics.CreateDrawingSurface2(_size, DirectXPixelFormat.B8G8R8A8UIntNormalized, DirectXAlphaMode.Premultiplied);
+                CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(_device, _scratchTexture, surface);
+                var timestamp = _player.PlaybackSession.Position;
+
+                result = new VideoFrame(surface, timestamp);
+            }
+            _currentFrameSource = null;
+
+            //global::System.Diagnostics.Debug.WriteLine("Get Frame End");
+
+            return result;
+        }
+
+        private void OnMediaEnded(MediaPlayer sender, object args)
+        {
+            _ended = true;
+            _endedSource.SetResult(false);
+        }
+
+        private void OnVideoFrameAvailable(MediaPlayer sender, object args)
+        {
+            //global::System.Diagnostics.Debug.WriteLine("Frame Available");
+            if (_currentFrameSource != null && !_currentFrameSource.Task.IsCompleted)
+            {
+                _currentFrameSource.SetResult(true);
+            }
+        }
+
+        public SizeInt32 Size => _size;
+    }
+    */
+
+    class VideoFrame
+    {
+        public CompositionDrawingSurface Surface { get; }
+        public TimeSpan Timestamp { get; }
+        public ulong FrameId { get; }
+
+        public static async Task<List<VideoFrame>> ExtractFramesAsync(MediaSource source, SizeInt32 size, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
+        {
+            var item = new MediaPlaybackItem(source);
+
+            var description = new Direct3D11Texture2DDescription();
+            description.Base = new Direct3DSurfaceDescription();
+            description.Base.Format = DirectXPixelFormat.B8G8R8A8UIntNormalized;
+            description.Base.Width = size.Width;
+            description.Base.Height = size.Height;
+            description.Base.MultisampleDescription = new Direct3DMultisampleDescription();
+            description.Base.MultisampleDescription.Count = 1;
+            description.Base.MultisampleDescription.Quality = 0;
+            description.ArraySize = 1;
+            description.BindFlags = Direct3DBindings.ShaderResource;
+            description.CpuAccessFlags = 0;
+            description.MiscFlags = 0;
+            description.MipLevels = 1;
+            var scratchTexture = device.CreateTexture2D(description);
+
+            var completion = new TaskCompletionSource<List<VideoFrame>>();
+            var frames = new List<VideoFrame>();
+            ulong frameId = 0;
+            var player = new MediaPlayer();
+            player.IsVideoFrameServerEnabled = true;
+            player.VideoFrameAvailable += (s, a) =>
+            {
+                lock (frames)
+                {
+                    player.CopyFrameToVideoSurface(scratchTexture);
+                    var surface = compGraphics.CreateDrawingSurface2(size, DirectXPixelFormat.B8G8R8A8UIntNormalized, DirectXAlphaMode.Premultiplied);
+                    CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(device, scratchTexture, surface);
+                    var timestamp = player.PlaybackSession.Position;
+                    frames.Add(new VideoFrame(surface, timestamp, ++frameId));
+                    player.StepForwardOneFrame();
+                }
+            };
+            player.MediaEnded += (s, a) =>
+            {
+                lock (frames)
+                {
+                    completion.SetResult(frames);
+                }
+            };
+            player.MediaFailed += (s, a) =>
+            {
+                completion.SetCanceled();
+            };
+            player.MediaOpened += (s, a) =>
+            {
+                player.StepForwardOneFrame();
+            };
+            player.AutoPlay = false;
+            player.Source = item;
+
+            return await completion.Task;
+        }
+
+        private VideoFrame(CompositionDrawingSurface surface, TimeSpan timestamp, ulong frameId)
+        {
+            Surface = surface;
+            Timestamp = timestamp;
+            FrameId = frameId;
+        }
+    }
+}

--- a/ImageViewer/FrameExtractor.cs
+++ b/ImageViewer/FrameExtractor.cs
@@ -1,32 +1,66 @@
 ﻿using ImageViewerNative;
 using System;
 using System.Collections.Generic;
+using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Windows.Graphics;
 using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
 using Windows.Storage.Streams;
 using Windows.UI.Composition;
+using Windows.UI.Xaml.Controls;
 using WinRTInteropTools;
 
 namespace ImageViewer
 {
     class VideoFrame
     {
-        public CompositionDrawingSurface Surface { get; }
+        public CompositionDrawingSurface Thumbnail { get; }
+        public Direct3D11Texture2D Surface { get; }
         public TimeSpan Timestamp { get; }
         public ulong FrameId { get; }
 
-        public static async Task<List<VideoFrame>> ExtractFramesAsync(IRandomAccessStream stream, SizeInt32 size, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
+        public static async Task<List<VideoFrame>> ExtractFramesAsync(IRandomAccessStream stream, Direct3D11Device device, CompositionGraphicsDevice compGraphics)
         {
             var frames = await Task.Run(() =>
             {
                 var result = new List<VideoFrame>();
+                var context = device.ImmediateContext;
+                var multithread = device.Multithread;
+                multithread.IsMultithreadProtected = true;
 
                 VideoFrameExtractor.ExtractFromStream(stream, device, (s, args) =>
                 {
-                    var surface = compGraphics.CreateDrawingSurface2(size, DirectXPixelFormat.B8G8R8A8UIntNormalized, DirectXAlphaMode.Premultiplied);
-                    CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(device, args.Surface, surface);
-                    result.Add(new VideoFrame(surface, args.Timestamp, args.FrameId));
+                    var sourceSurface = args.Surface;
+                    var sourceDescription = sourceSurface.Description;
+
+                    Direct3D11Texture2D texture;
+                    using (var session = multithread.Lock())
+                    {
+                        var description = new Direct3D11Texture2DDescription();
+                        description.Base = new Direct3DSurfaceDescription();
+                        description.Base.Format = DirectXPixelFormat.B8G8R8A8UIntNormalized;
+                        description.Base.Width = sourceDescription.Width;
+                        description.Base.Height = sourceDescription.Height;
+                        description.Base.MultisampleDescription = new Direct3DMultisampleDescription();
+                        description.Base.MultisampleDescription.Count = 1;
+                        description.Base.MultisampleDescription.Quality = 0;
+                        description.ArraySize = 1;
+                        description.BindFlags = Direct3DBindings.ShaderResource;
+                        description.CpuAccessFlags = 0;
+                        description.MiscFlags = 0;
+                        description.MipLevels = 1;
+                        texture = device.CreateTexture2D(description);
+                        context.CopyResource(texture, sourceSurface);
+                    }
+
+                    var surface = compGraphics.CreateDrawingSurface2(
+                        new SizeInt32() { Width = sourceDescription.Width, Height = sourceDescription.Height },
+                        DirectXPixelFormat.B8G8R8A8UIntNormalized,
+                        DirectXAlphaMode.Premultiplied);
+                    CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(device, texture, surface);
+                    
+                    result.Add(new VideoFrame(surface, texture, args.Timestamp, args.FrameId));
                 });
 
                 return result;
@@ -35,8 +69,9 @@ namespace ImageViewer
             return frames;
         }
 
-        private VideoFrame(CompositionDrawingSurface surface, TimeSpan timestamp, ulong frameId)
+        private VideoFrame(CompositionDrawingSurface thumbnail, Direct3D11Texture2D surface, TimeSpan timestamp, ulong frameId)
         {
+            Thumbnail = thumbnail;
             Surface = surface;
             Timestamp = timestamp;
             FrameId = frameId;

--- a/ImageViewer/FrameExtractor.cs
+++ b/ImageViewer/FrameExtractor.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using ImageViewerNative;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,6 +15,7 @@ using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage.Streams;
 using Windows.UI.Composition;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Maps;
 using WinRTInteropTools;
 
@@ -24,65 +27,23 @@ namespace ImageViewer
         public TimeSpan Timestamp { get; }
         public ulong FrameId { get; }
 
-        public static async Task<List<VideoFrame>> ExtractFramesAsync(MediaSource source, SizeInt32 size, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
+        public static async Task<List<VideoFrame>> ExtractFramesAsync(IRandomAccessStream stream, SizeInt32 size, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
         {
-            var item = new MediaPlaybackItem(source);
-            var stopwatch = new Stopwatch();
-
-            var description = new Direct3D11Texture2DDescription();
-            description.Base = new Direct3DSurfaceDescription();
-            description.Base.Format = DirectXPixelFormat.B8G8R8A8UIntNormalized;
-            description.Base.Width = size.Width;
-            description.Base.Height = size.Height;
-            description.Base.MultisampleDescription = new Direct3DMultisampleDescription();
-            description.Base.MultisampleDescription.Count = 1;
-            description.Base.MultisampleDescription.Quality = 0;
-            description.ArraySize = 1;
-            description.BindFlags = Direct3DBindings.ShaderResource;
-            description.CpuAccessFlags = 0;
-            description.MiscFlags = 0;
-            description.MipLevels = 1;
-            var scratchTexture = device.CreateTexture2D(description);
-
-            var completion = new TaskCompletionSource<List<VideoFrame>>();
-            var frames = new List<VideoFrame>();
-            ulong frameId = 0;
-            var player = new MediaPlayer();
-            player.IsVideoFrameServerEnabled = true;
-            player.VideoFrameAvailable += (s, a) =>
+            var frames = await Task.Run(() =>
             {
-                lock (frames)
+                var result = new List<VideoFrame>();
+
+                VideoFrameExtractor.ExtractFromStream(stream, device, (s, args) =>
                 {
-                    player.CopyFrameToVideoSurface(scratchTexture);
                     var surface = compGraphics.CreateDrawingSurface2(size, DirectXPixelFormat.B8G8R8A8UIntNormalized, DirectXAlphaMode.Premultiplied);
-                    CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(device, scratchTexture, surface);
-                    var timestamp = player.PlaybackSession.Position;
-                    frames.Add(new VideoFrame(surface, timestamp, ++frameId));
-                    player.StepForwardOneFrame();
-                }
-            };
-            player.MediaEnded += (s, a) =>
-            {
-                lock (frames)
-                {
-                    completion.SetResult(frames);
-                    stopwatch.Stop();
-                    global::System.Diagnostics.Debug.WriteLine($"VIDEO FRAME EXTRACTION TIME: {stopwatch.Elapsed}");
-                }
-            };
-            player.MediaFailed += (s, a) =>
-            {
-                completion.SetCanceled();
-            };
-            player.MediaOpened += (s, a) =>
-            {
-                stopwatch.Start();
-                player.StepForwardOneFrame();
-            };
-            player.AutoPlay = false;
-            player.Source = item;
+                    CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(device, args.Surface, surface);
+                    result.Add(new VideoFrame(surface, args.Timestamp, args.FrameId));
+                });
 
-            return await completion.Task;
+                return result;
+            });
+
+            return frames;
         }
 
         private VideoFrame(CompositionDrawingSurface surface, TimeSpan timestamp, ulong frameId)

--- a/ImageViewer/FrameExtractor.cs
+++ b/ImageViewer/FrameExtractor.cs
@@ -1,22 +1,11 @@
 ﻿using ImageViewerNative;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Graphics;
 using Windows.Graphics.DirectX;
-using Windows.Graphics.DirectX.Direct3D11;
-using Windows.Graphics.Imaging;
-using Windows.Media.Core;
-using Windows.Media.Playback;
 using Windows.Storage.Streams;
 using Windows.UI.Composition;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Maps;
 using WinRTInteropTools;
 
 namespace ImageViewer

--- a/ImageViewer/FrameExtractor.cs
+++ b/ImageViewer/FrameExtractor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -17,113 +18,6 @@ using WinRTInteropTools;
 
 namespace ImageViewer
 {
-    /*
-    class FrameExtractor
-    {
-        private MediaPlayer _player;
-        private SizeInt32 _size;
-        private CompositionGraphicsDevice _compGraphics;
-        private Direct3D11Device _device;
-        private Direct3D11Texture2D _scratchTexture;
-
-        private bool _ended = false;
-        private TaskCompletionSource<bool> _currentFrameSource = null;
-        private TaskCompletionSource<bool> _endedSource;
-
-        public FrameExtractor(MediaSource source, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
-        {
-            var item = new MediaPlaybackItem(source);
-            var bitmapSize = new BitmapSize() { Width = 0, Height = 0 };
-            foreach (var track in item.VideoTracks)
-            {
-                var properties = track.GetEncodingProperties();
-                if (bitmapSize.Width < properties.Width && bitmapSize.Height < properties.Height)
-                {
-                    bitmapSize.Width = properties.Width;
-                    bitmapSize.Height = properties.Height;
-                }
-            }
-            _size = new SizeInt32() { Width = (int)bitmapSize.Width, Height = (int)bitmapSize.Height };
-
-            _compGraphics = compGraphics;
-            _device = device;
-            _endedSource = new TaskCompletionSource<bool>();
-
-            var description = new Direct3D11Texture2DDescription();
-            description.Base = new Direct3DSurfaceDescription();
-            description.Base.Format = DirectXPixelFormat.B8G8R8A8UIntNormalized;
-            description.Base.Width = _size.Width;
-            description.Base.Height = _size.Height;
-            description.Base.MultisampleDescription = new Direct3DMultisampleDescription();
-            description.Base.MultisampleDescription.Count = 1;
-            description.Base.MultisampleDescription.Quality = 0;
-            description.ArraySize = 1;
-            description.BindFlags = Direct3DBindings.ShaderResource;
-            description.CpuAccessFlags = 0;
-            description.MiscFlags = 0;
-            description.MipLevels = 1;
-            _scratchTexture = device.CreateTexture2D(description);
-
-            _player = new MediaPlayer();
-            _player.IsVideoFrameServerEnabled = true;
-            _player.AutoPlay = false;
-            _player.VideoFrameAvailable += OnVideoFrameAvailable;
-            _player.MediaEnded += OnMediaEnded;
-            _player.Media
-            _player.Source = item;
-            _player.Pause();
-        }
-
-        public async Task<VideoFrame> TryGetNextFrameAsync()
-        {
-            if (_ended)
-            {
-                return null;
-            }
-
-            //global::System.Diagnostics.Debug.WriteLine("Get Frame Start");
-
-            global::System.Diagnostics.Debug.Assert(_currentFrameSource == null);
-            _currentFrameSource = new TaskCompletionSource<bool>();
-            _player.StepForwardOneFrame();
-
-            VideoFrame result = null;
-            var task = await Task.WhenAny(_currentFrameSource.Task, _endedSource.Task);
-            if (task == _currentFrameSource.Task && task.Result)
-            {
-                _player.CopyFrameToVideoSurface(_scratchTexture);
-                var surface = _compGraphics.CreateDrawingSurface2(_size, DirectXPixelFormat.B8G8R8A8UIntNormalized, DirectXAlphaMode.Premultiplied);
-                CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(_device, _scratchTexture, surface);
-                var timestamp = _player.PlaybackSession.Position;
-
-                result = new VideoFrame(surface, timestamp);
-            }
-            _currentFrameSource = null;
-
-            //global::System.Diagnostics.Debug.WriteLine("Get Frame End");
-
-            return result;
-        }
-
-        private void OnMediaEnded(MediaPlayer sender, object args)
-        {
-            _ended = true;
-            _endedSource.SetResult(false);
-        }
-
-        private void OnVideoFrameAvailable(MediaPlayer sender, object args)
-        {
-            //global::System.Diagnostics.Debug.WriteLine("Frame Available");
-            if (_currentFrameSource != null && !_currentFrameSource.Task.IsCompleted)
-            {
-                _currentFrameSource.SetResult(true);
-            }
-        }
-
-        public SizeInt32 Size => _size;
-    }
-    */
-
     class VideoFrame
     {
         public CompositionDrawingSurface Surface { get; }
@@ -133,6 +27,7 @@ namespace ImageViewer
         public static async Task<List<VideoFrame>> ExtractFramesAsync(MediaSource source, SizeInt32 size, CompositionGraphicsDevice compGraphics, Direct3D11Device device)
         {
             var item = new MediaPlaybackItem(source);
+            var stopwatch = new Stopwatch();
 
             var description = new Direct3D11Texture2DDescription();
             description.Base = new Direct3DSurfaceDescription();
@@ -171,6 +66,8 @@ namespace ImageViewer
                 lock (frames)
                 {
                     completion.SetResult(frames);
+                    stopwatch.Stop();
+                    global::System.Diagnostics.Debug.WriteLine($"VIDEO FRAME EXTRACTION TIME: {stopwatch.Elapsed}");
                 }
             };
             player.MediaFailed += (s, a) =>
@@ -179,6 +76,7 @@ namespace ImageViewer
             };
             player.MediaOpened += (s, a) =>
             {
+                stopwatch.Start();
                 player.StepForwardOneFrame();
             };
             player.AutoPlay = false;

--- a/ImageViewer/Image.cs
+++ b/ImageViewer/Image.cs
@@ -634,10 +634,11 @@ namespace ImageViewer
         {
             if (_videoFrames == null)
             {
-                var source = MediaSource.CreateFromStorageFile(_file);
-                await source.OpenAsync();
-                var size = new SizeInt32() { Width = (int)Size.Width, Height = (int)Size.Height };
-                _videoFrames = await VideoFrame.ExtractFramesAsync(source, size, compGraphics, device);
+                using (var stream = await _file.OpenReadAsync())
+                {
+                    var size = new SizeInt32() { Width = (int)Size.Width, Height = (int)Size.Height };
+                    _videoFrames = await VideoFrame.ExtractFramesAsync(stream, size, compGraphics, device);
+                }
             }
         }
     }

--- a/ImageViewer/Image.cs
+++ b/ImageViewer/Image.cs
@@ -534,22 +534,13 @@ namespace ImageViewer
             }
         }
 
-        public void SetPosition(TimeSpan position)
+        private void OnSliderValueChanged(object sender, Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
         {
-            _player.PlaybackSession.Position = position;
+            _player.PlaybackSession.Position = TimeSpan.FromSeconds(e.NewValue);
             if (!_isPlaying)
             {
                 QueueDelayedUpdateToPauseData(3000);
             }
-            if (_boundSlider != null)
-            {
-                _boundSlider.Value = _player.PlaybackSession.Position.TotalSeconds;
-            }
-        }
-
-        private void OnSliderValueChanged(object sender, Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
-        {
-            SetPosition(TimeSpan.FromSeconds(e.NewValue));
         }
 
         private CanvasBitmap GetCurrentBitmap()

--- a/ImageViewer/Image.cs
+++ b/ImageViewer/Image.cs
@@ -641,7 +641,7 @@ namespace ImageViewer
         private CompositionDrawingSurface _surface;
         private int _selectedIndex = -1;
 
-        public IEnumerable<VideoFrame> VideoFrames => _videoFrames;
+        public IReadOnlyList<VideoFrame> VideoFrames => _videoFrames;
         public int SelectedIndex
         {
             get { return _selectedIndex; }

--- a/ImageViewer/Image.cs
+++ b/ImageViewer/Image.cs
@@ -3,7 +3,6 @@ using ImageViewer.ScreenCapture;
 using ImageViewer.System;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.UI.Composition;
-using Microsoft.Toolkit.Uwp.UI.Controls.TextToolbarSymbols;
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/ImageViewer/Image.cs
+++ b/ImageViewer/Image.cs
@@ -589,6 +589,7 @@ namespace ImageViewer
                 _player.Pause();
                 _player.Dispose();
                 _player = null;
+                _pauseDataUpdateTimer.Dispose();
             }
         }
 

--- a/ImageViewer/Image.cs
+++ b/ImageViewer/Image.cs
@@ -12,6 +12,7 @@ using Windows.Graphics;
 using Windows.Graphics.Capture;
 using Windows.Graphics.DirectX;
 using Windows.Graphics.Imaging;
+using Windows.Media;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage;
@@ -421,9 +422,6 @@ namespace ImageViewer
         private DispatcherQueueTimer _playbackTimer = null;
         private Windows.UI.Xaml.Controls.Slider _boundSlider = null;
 
-        private List<VideoFrame> _videoFrames = null;
-        public IEnumerable<VideoFrame> VideoFrames => _videoFrames;
-
         private VideoImage(StorageFile file, MediaPlaybackItem item)
         {
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
@@ -629,15 +627,138 @@ namespace ImageViewer
             }
         }
 
-        public async Task EnsureVideoFramesAsync(CompositionGraphicsDevice compGraphics, Direct3D11Device device)
+        public Task<FrameByFrameVideoImage> CreateFrameByFrameVideoImageAsync(Direct3D11Device device, CompositionGraphicsDevice compGraphics)
         {
-            if (_videoFrames == null)
+            return FrameByFrameVideoImage.CreateAsync(_file, device, compGraphics);
+        }
+    }
+
+    class FrameByFrameVideoImage : IImage
+    {
+        public static async Task<FrameByFrameVideoImage> CreateAsync(StorageFile file, Direct3D11Device device, CompositionGraphicsDevice compGraphics)
+        {
+            using (var stream = await file.OpenReadAsync())
             {
-                using (var stream = await _file.OpenReadAsync())
+                var videoFrames = await VideoFrame.ExtractFramesAsync(stream, device, compGraphics);
+                return new FrameByFrameVideoImage(file, device, compGraphics, videoFrames);
+            }
+        }
+
+        private StorageFile _file;
+        private Direct3D11Device _device;
+        private List<VideoFrame> _videoFrames;
+        private CompositionDrawingSurface _surface;
+        private int _selectedIndex = -1;
+
+        public IEnumerable<VideoFrame> VideoFrames => _videoFrames;
+        public int SelectedIndex
+        {
+            get { return _selectedIndex; }
+            set
+            {
+                if (value >= 0 && value < _videoFrames.Count)
                 {
-                    var size = new SizeInt32() { Width = (int)Size.Width, Height = (int)Size.Height };
-                    _videoFrames = await VideoFrame.ExtractFramesAsync(stream, size, compGraphics, device);
+                    _selectedIndex = value;
+                    RegenerateSurface();
                 }
+                else
+                {
+                    _selectedIndex = -1;
+                }
+            }
+        }
+
+        private FrameByFrameVideoImage(StorageFile file, Direct3D11Device device, CompositionGraphicsDevice compGraphics,  List<VideoFrame> frames)
+        {
+            _file = file;
+            _videoFrames = frames;
+            _device = device;
+            DisplayName = file.Name;
+
+            // All frames should be the same size
+            var description = _videoFrames[0].Surface.Description;
+            Size = new BitmapSize() { Width = (uint)description.Width, Height = (uint)description.Height };
+
+            _surface = compGraphics.CreateDrawingSurface2(Size.ToSizeInt32(), DirectXPixelFormat.B8G8R8A8UIntNormalized, DirectXAlphaMode.Premultiplied);
+        }
+
+        public string DisplayName { get; }
+
+        public BitmapSize Size { get; }
+
+        public ICompositionSurface CreateSurface(CompositionGraphicsDevice graphics)
+        {
+            return _surface;
+        }
+
+        public void Dispose()
+        {
+            // TODO
+        }
+
+        public Color? GetColorFromPixel(int x, int y)
+        {
+            var frame = TryGetCurrentFrame();
+            if (frame != null)
+            {
+                var desc = frame.Surface.Description;
+                if (x >= 0 && x < desc.Width && y >= 0 && y < desc.Height)
+                {
+                    var bytes = frame.Surface.GetBytes();
+
+                    var index = ((y * desc.Width) + x) * 4; // BGRA8
+                    var blue = bytes[index + 0];
+                    var green = bytes[index + 1];
+                    var red = bytes[index + 2];
+                    var alpha = bytes[index + 3];
+
+                    return new Color() { B = blue, G = green, R = red, A = alpha };
+                }
+            }
+            return null;
+        }
+
+        public void RegenerateSurface()
+        {
+            var frame = TryGetCurrentFrame();
+            if (frame != null && _surface != null)
+            {
+                CompositionGraphics.CopyDirect3DSurfaceIntoCompositionSurface(_device, frame.Surface, _surface);
+            }
+        }
+
+        public async Task SaveSnapshotToStreamAsync(IRandomAccessStream stream, ImageFormat format)
+        {
+            switch (format)
+            {
+                case ImageFormat.Png:
+                    {
+                        var bitmap = await SoftwareBitmap.CreateCopyFromSurfaceAsync(TryGetCurrentFrame().Surface);
+                        var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
+                        encoder.SetSoftwareBitmap(bitmap);
+                        await encoder.FlushAsync();
+                    }
+                    break;
+                case ImageFormat.RawBgra8:
+                    {
+                        var bytes = TryGetCurrentFrame().Surface.GetBytes();
+                        await RmRaw.WriteImageAsync(stream, Size.Width, Size.Height, RmRawPixelFormat.BGRA8, bytes);
+                    }
+                    break;
+                default:
+                    throw new ArgumentException();
+            }
+        }
+
+        private VideoFrame TryGetCurrentFrame()
+        {
+            if (_selectedIndex < 0 || _selectedIndex >= _videoFrames.Count)
+            {
+                return null;
+            }
+            else
+            {
+                return _videoFrames[_selectedIndex];
             }
         }
     }

--- a/ImageViewer/ImageViewer.csproj
+++ b/ImageViewer/ImageViewer.csproj
@@ -142,6 +142,7 @@
       <DependentUpon>BinaryDetailsInputDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="FileFormats\RmRaw.cs" />
+    <Compile Include="FrameExtractor.cs" />
     <Compile Include="System\ApplicationSettings.cs" />
     <Compile Include="System\Capabilities.cs" />
     <Compile Include="ScreenCapture\CaptureSnapshot.cs" />

--- a/ImageViewer/ImageViewer.csproj
+++ b/ImageViewer/ImageViewer.csproj
@@ -293,7 +293,12 @@
   <ItemGroup>
     <None Include="ImageViewer_TemporaryKey.pfx" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\ImageViewerNative\ImageViewerNative.vcxproj">
+      <Project>{ec7bc29a-fbba-4a3b-abcb-9bba4dc76ee3}</Project>
+      <Name>ImageViewerNative</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/ImageViewer/ImageViewer.csproj
+++ b/ImageViewer/ImageViewer.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Dialogs\BinaryDetailsInputDialog.xaml.cs">
       <DependentUpon>BinaryDetailsInputDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Extensions.cs" />
     <Compile Include="FileFormats\RmRaw.cs" />
     <Compile Include="FrameExtractor.cs" />
     <Compile Include="System\ApplicationSettings.cs" />

--- a/ImageViewer/InteropBrush.cs
+++ b/ImageViewer/InteropBrush.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.UI.Composition;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
 namespace ImageViewer
@@ -13,6 +14,46 @@ namespace ImageViewer
         public void SetBrush(CompositionBrush brush)
         {
             CompositionBrush = brush;
+        }
+    }
+
+    class BindableCompositionSurfaceBrush : XamlCompositionBrushBase
+    {
+        private static readonly DependencyProperty SurfaceProperty = DependencyProperty.Register(nameof(Surface), typeof(ICompositionSurface), typeof(BindableCompositionSurfaceBrush), new PropertyMetadata(null, OnSurfaceChanged));
+
+        private static void OnSurfaceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var oldValue = e.OldValue as ICompositionSurface;
+            var newValue = e.NewValue as ICompositionSurface;
+
+            if (oldValue != newValue)
+            {
+                var self = (BindableCompositionSurfaceBrush)d;
+                self.SetSurface(newValue);
+            }
+        }
+
+        CompositionSurfaceBrush EnsureBrush(Compositor compositor)
+        {
+            if (CompositionBrush == null)
+            {
+                var brush = compositor.CreateSurfaceBrush();
+                brush.Stretch = CompositionStretch.Uniform;
+                CompositionBrush = brush;
+            }
+            return (CompositionSurfaceBrush)CompositionBrush;
+        }
+
+        public ICompositionSurface Surface
+        {
+            get { return (ICompositionSurface)GetValue(SurfaceProperty); }
+            set { SetValue(SurfaceProperty, value); }
+        }
+
+        private void SetSurface(ICompositionSurface surface)
+        {
+            var brush = EnsureBrush(Window.Current.Compositor);
+            brush.Surface = surface;
         }
     }
 }

--- a/ImageViewer/Pages/MainPage.xaml
+++ b/ImageViewer/Pages/MainPage.xaml
@@ -136,7 +136,11 @@
                         </StackPanel>
                     </AppBarElementContainer>
                     <AppBarSeparator />
-                    <AppBarButton x:Name="FrameByFrameVideoButton" Icon="ShowBcc" Label="Open as frame by frame" Click="FrameByFrameVideoButton_Click" />
+                    <AppBarButton x:Name="FrameByFrameVideoButton" Label="Open as frame by frame" Click="FrameByFrameVideoButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE7C5;" />
+                        </AppBarButton.Icon>
+                    </AppBarButton>
                 </wctc:TabbedCommandBarItem>
                 <wctc:TabbedCommandBarItem x:Name="FrameByFrameVideoMenu" Header="Frame By Frame" IsContextual="True" Visibility="Collapsed">
                     <AppBarButton Icon="Previous" Label="Previous Frame" Click="FrameByFrameVideoPreviousFrameButton_Click" />
@@ -152,6 +156,12 @@
                     <AppBarElementContainer HorizontalAlignment="Stretch" Margin="5, 0, 5, 0">
                         <Slider x:Name="FrameByFrameVideoPlayerSeekSlider" HorizontalAlignment="Stretch" MinWidth="250" MaxWidth="400" Value="{Binding ElementName=VideoTimelineListView, Path=SelectedIndex, Mode=TwoWay}" ValueChanged="FrameByFrameVideoPlayerSeekSlider_ValueChanged" />
                     </AppBarElementContainer>
+                    <AppBarSeparator />
+                    <AppBarButton Label="Scroll to selected frame" Click="FrameByFrameVideoScrollIntoViewButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE890;" />
+                        </AppBarButton.Icon>
+                    </AppBarButton>
                 </wctc:TabbedCommandBarItem>
             </wctc:TabbedCommandBar.MenuItems>
         </wctc:TabbedCommandBar>

--- a/ImageViewer/Pages/MainPage.xaml
+++ b/ImageViewer/Pages/MainPage.xaml
@@ -138,6 +138,21 @@
                     <AppBarSeparator />
                     <AppBarButton x:Name="FrameByFrameVideoButton" Icon="ShowBcc" Label="Open as frame by frame" Click="FrameByFrameVideoButton_Click" />
                 </wctc:TabbedCommandBarItem>
+                <wctc:TabbedCommandBarItem x:Name="FrameByFrameVideoMenu" Header="Frame By Frame" IsContextual="True" Visibility="Collapsed">
+                    <AppBarButton Icon="Previous" Label="Previous Frame" Click="FrameByFrameVideoPreviousFrameButton_Click" />
+                    <AppBarButton Icon="Next" Label="Next Frame" Click="FrameByFrameVideoNextFrameButton_Click" />
+                    <AppBarSeparator />
+                    <AppBarElementContainer Margin="5, 0, 5, 0">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding ElementName=VideoTimelineListView, Path=SelectedItem.Timestamp, Mode=OneWay}" />
+                            <TextBlock Text="/" />
+                            <TextBlock x:Name="FrameByFrameMaxTimeTextBlock" Text="" />
+                        </StackPanel>
+                    </AppBarElementContainer>
+                    <AppBarElementContainer HorizontalAlignment="Stretch" Margin="5, 0, 5, 0">
+                        <Slider x:Name="FrameByFrameVideoPlayerSeekSlider" HorizontalAlignment="Stretch" MinWidth="250" MaxWidth="400" Value="{Binding ElementName=VideoTimelineListView, Path=SelectedIndex, Mode=TwoWay}" ValueChanged="FrameByFrameVideoPlayerSeekSlider_ValueChanged" />
+                    </AppBarElementContainer>
+                </wctc:TabbedCommandBarItem>
             </wctc:TabbedCommandBar.MenuItems>
         </wctc:TabbedCommandBar>
 

--- a/ImageViewer/Pages/MainPage.xaml
+++ b/ImageViewer/Pages/MainPage.xaml
@@ -136,7 +136,7 @@
                         </StackPanel>
                     </AppBarElementContainer>
                     <AppBarSeparator />
-                    <AppBarToggleButton x:Name="VideoShowFramesButton" Icon="ShowBcc" Label="Show/Hide Frames View" Checked="VideoShowFramesButton_Checked" Unchecked="VideoShowFramesButton_Unchecked" />
+                    <AppBarButton x:Name="FrameByFrameVideoButton" Icon="ShowBcc" Label="Open as frame by frame" Click="FrameByFrameVideoButton_Click" />
                 </wctc:TabbedCommandBarItem>
             </wctc:TabbedCommandBar.MenuItems>
         </wctc:TabbedCommandBar>
@@ -150,12 +150,12 @@
             <controls:ImageViewer x:Name="MainImageViewer" Grid.Column="0" AllowDrop="True" DragOver="MainImageViewer_DragOver" Drop="MainImageViewer_Drop" />
 
             <Grid x:Name="VideoTimelineGrid" Grid.Column="1" Visibility="Collapsed">
-                <ListView x:Name="VideoTimelineListView" IsItemClickEnabled="True" ItemClick="VideoTimelineListView_ItemClick">
+                <ListView x:Name="VideoTimelineListView" SelectionChanged="VideoTimelineListView_SelectionChanged">
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="300" Height="200">
                                 <Rectangle.Fill>
-                                    <local:BindableCompositionSurfaceBrush Surface="{Binding Surface}" />
+                                    <local:BindableCompositionSurfaceBrush Surface="{Binding Thumbnail}" />
                                 </Rectangle.Fill>
                             </Rectangle>
                         </DataTemplate>

--- a/ImageViewer/Pages/MainPage.xaml
+++ b/ImageViewer/Pages/MainPage.xaml
@@ -135,11 +135,34 @@
                             </ComboBox>
                         </StackPanel>
                     </AppBarElementContainer>
+                    <AppBarSeparator />
+                    <AppBarToggleButton x:Name="VideoShowFramesButton" Icon="ShowBcc" Label="Show/Hide Frames View" Checked="VideoShowFramesButton_Checked" Unchecked="VideoShowFramesButton_Unchecked" />
                 </wctc:TabbedCommandBarItem>
             </wctc:TabbedCommandBar.MenuItems>
         </wctc:TabbedCommandBar>
 
-        <controls:ImageViewer x:Name="MainImageViewer" Grid.Row="1" AllowDrop="True" DragOver="MainImageViewer_DragOver" Drop="MainImageViewer_Drop" />
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            
+            <controls:ImageViewer x:Name="MainImageViewer" Grid.Column="0" AllowDrop="True" DragOver="MainImageViewer_DragOver" Drop="MainImageViewer_Drop" />
+
+            <Grid x:Name="VideoTimelineGrid" Grid.Column="1" Visibility="Collapsed">
+                <ListView x:Name="VideoTimelineListView" IsItemClickEnabled="True" ItemClick="VideoTimelineListView_ItemClick">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Rectangle Width="300" Height="200">
+                                <Rectangle.Fill>
+                                    <local:BindableCompositionSurfaceBrush Surface="{Binding Surface}" />
+                                </Rectangle.Fill>
+                            </Rectangle>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </Grid>
+        </Grid>
 
         <Grid Grid.Row="2" Background="{Binding Background, ElementName=MainMenu, Mode=OneWay}" >
             <Grid.ColumnDefinitions>

--- a/ImageViewer/Pages/MainPage.xaml.cs
+++ b/ImageViewer/Pages/MainPage.xaml.cs
@@ -239,6 +239,8 @@ namespace ImageViewer.Pages
                     return CaptureMenu;
                 case ViewMode.Video:
                     return VideoMenu;
+                case ViewMode.FrameByFrameVideo:
+                    return FrameByFrameVideoMenu;
                 default:
                     return ViewMenu;
             }
@@ -250,6 +252,7 @@ namespace ImageViewer.Pages
             DiffMenu.Visibility = viewMode == ViewMode.Diff ? Visibility.Visible : Visibility.Collapsed;
             CaptureMenu.Visibility = viewMode == ViewMode.Capture ? Visibility.Visible : Visibility.Collapsed;
             VideoMenu.Visibility = viewMode == ViewMode.Video ? Visibility.Visible : Visibility.Collapsed;
+            FrameByFrameVideoMenu.Visibility = viewMode == ViewMode.FrameByFrameVideo ? Visibility.Visible : Visibility.Collapsed;
             MainMenu.SelectedItem = GetMenuForViewMode(viewMode);
             VideoTimelineGrid.Visibility = viewMode == ViewMode.FrameByFrameVideo ? Visibility.Visible : Visibility.Collapsed;
             var size = MainImageViewer.Image.Size;
@@ -272,6 +275,8 @@ namespace ImageViewer.Pages
             else if (viewMode == ViewMode.FrameByFrameVideo)
             {
                 var videoImage = (FrameByFrameVideoImage)MainImageViewer.Image;
+                FrameByFrameVideoPlayerSeekSlider.Maximum = videoImage.VideoFrames.Count;
+                FrameByFrameMaxTimeTextBlock.Text = videoImage.VideoFrames.Last().Timestamp.ToString();
                 VideoTimelineListView.ItemsSource = videoImage.VideoFrames;
                 VideoTimelineListView.SelectedIndex = 0;
             }
@@ -784,6 +789,50 @@ namespace ImageViewer.Pages
             if (MainImageViewer != null && MainImageViewer.Image is FrameByFrameVideoImage image)
             {
                 image.SelectedIndex = ((ListView)sender).SelectedIndex;
+            }
+        }
+
+        private void FrameByFrameVideoPreviousFrameButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MainImageViewer != null && MainImageViewer.Image is FrameByFrameVideoImage image)
+            {
+                var index = VideoTimelineListView.SelectedIndex - 1;
+                if (index < 0)
+                {
+                    VideoTimelineListView.SelectedIndex = 0;
+                }
+                else if (index < image.VideoFrames.Count)
+                {
+                    VideoTimelineListView.SelectedIndex = index;
+                }
+            }
+        }
+
+        private void FrameByFrameVideoNextFrameButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MainImageViewer != null && MainImageViewer.Image is FrameByFrameVideoImage image)
+            {
+                var index = VideoTimelineListView.SelectedIndex + 1;
+                if (index < 0)
+                {
+                    VideoTimelineListView.SelectedIndex = 0;
+                }
+                else if (index < image.VideoFrames.Count)
+                {
+                    VideoTimelineListView.SelectedIndex = index;
+                }
+            }
+        }
+
+        private void FrameByFrameVideoPlayerSeekSlider_ValueChanged(object sender, Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            if (MainImageViewer != null && MainImageViewer.Image is FrameByFrameVideoImage image)
+            {
+                var index = VideoTimelineListView.SelectedIndex;
+                if (index >= 0 && index < image.VideoFrames.Count)
+                {
+                    VideoTimelineListView.ScrollIntoView(image.VideoFrames[index]);
+                }
             }
         }
     }

--- a/ImageViewer/Pages/MainPage.xaml.cs
+++ b/ImageViewer/Pages/MainPage.xaml.cs
@@ -779,7 +779,10 @@ namespace ImageViewer.Pages
         {
             if (MainImageViewer != null && MainImageViewer.Image is VideoImage image)
             {
+                image.Pause();
+                IsEnabled = false;
                 var newImage = await image.CreateFrameByFrameVideoImageAsync(GraphicsManager.Current.CaptureDevice, GraphicsManager.Current.CompositionGraphicsDeviceForCapture);
+                IsEnabled = true;
                 OpenImage(newImage, ViewMode.FrameByFrameVideo);
             }
         }
@@ -825,6 +828,18 @@ namespace ImageViewer.Pages
         }
 
         private void FrameByFrameVideoPlayerSeekSlider_ValueChanged(object sender, Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            if (MainImageViewer != null && MainImageViewer.Image is FrameByFrameVideoImage image)
+            {
+                var index = VideoTimelineListView.SelectedIndex;
+                if (index >= 0 && index < image.VideoFrames.Count)
+                {
+                    VideoTimelineListView.ScrollIntoView(image.VideoFrames[index]);
+                }
+            }
+        }
+
+        private void FrameByFrameVideoScrollIntoViewButton_Click(object sender, RoutedEventArgs e)
         {
             if (MainImageViewer != null && MainImageViewer.Image is FrameByFrameVideoImage image)
             {

--- a/ImageViewer/Pages/MainPage.xaml.cs
+++ b/ImageViewer/Pages/MainPage.xaml.cs
@@ -761,5 +761,30 @@ namespace ImageViewer.Pages
                     return FileType.Unknown;
             }
         }
+
+        private async void VideoShowFramesButton_Checked(object sender, RoutedEventArgs e)
+        {
+            if (MainImageViewer != null && MainImageViewer.Image is VideoImage image)
+            {
+                await image.EnsureVideoFramesAsync(GraphicsManager.Current.CompositionGraphicsDeviceForCapture, GraphicsManager.Current.CaptureDevice);
+                VideoTimelineListView.ItemsSource = image.VideoFrames;
+                VideoTimelineGrid.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void VideoShowFramesButton_Unchecked(object sender, RoutedEventArgs e)
+        {
+            VideoTimelineGrid.Visibility = Visibility.Collapsed;
+        }
+
+        private void VideoTimelineListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            if (MainImageViewer != null && MainImageViewer.Image is VideoImage image)
+            {
+                var frame = (VideoFrame)e.ClickedItem;
+                image.Pause();
+                image.SetPosition(frame.Timestamp);
+            }
+        }
     }
 }

--- a/ImageViewer/System/GraphicsManager.cs
+++ b/ImageViewer/System/GraphicsManager.cs
@@ -25,6 +25,7 @@ namespace ImageViewer.System
         }
 
         private Direct3D11Device _captureDevice = null;
+        private CompositionGraphicsDevice _compGraphicsForCapture = null;
         private DeviceLostWatcher _canvasWatcher;
         private DeviceLostWatcher _captureWatcher;
 
@@ -69,8 +70,17 @@ namespace ImageViewer.System
                 {
                     _captureDevice = new Direct3D11Device();
                     _captureWatcher.WatchDevice(_captureDevice);
+                    _compGraphicsForCapture = CompositionGraphics.CreateCompositionGraphicsDevice(Compositor, _captureDevice);
                 }
                 return _captureDevice;
+            }
+        }
+        public CompositionGraphicsDevice CompositionGraphicsDeviceForCapture
+        {
+            get
+            {
+                var device = CaptureDevice;
+                return _compGraphicsForCapture;
             }
         }
 

--- a/ImageViewerNative/Fence.h
+++ b/ImageViewerNative/Fence.h
@@ -1,0 +1,45 @@
+#pragma once
+
+template <typename FenceT, typename ContextT>
+class Fence
+{
+public:
+	Fence(winrt::com_ptr<FenceT> const& fence, winrt::com_ptr<ContextT> const& context)
+	{
+		m_fence = fence;
+		m_context = context;
+		m_event.reset(winrt::check_pointer(CreateEventExW(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE)));
+	}
+
+	void WaitForGpu()
+	{
+		uint64_t fenceValue = m_value;
+		winrt::check_hresult(m_context->Signal(m_fence.get(), fenceValue));
+		winrt::check_hresult(m_fence->SetEventOnCompletion(fenceValue, m_event.get()));
+		m_event.wait();
+		m_value++;
+	}
+
+private:
+	winrt::com_ptr<FenceT> m_fence;
+	winrt::com_ptr<ContextT> m_context;
+	wil::unique_event m_event{ nullptr };
+	uint64_t m_value = 0;
+};
+
+//using D3D12Fence = Fence<ID3D12Fence, ID3D12CommandQueue>;
+using D3D11Fence = Fence<ID3D11Fence, ID3D11DeviceContext4>;
+
+//inline std::shared_ptr<D3D12Fence> CreateD3D12Fence(winrt::com_ptr<ID3D12Device> const& d3d12Device, winrt::com_ptr<ID3D12CommandQueue> const& d3d12CommandQueue)
+//{
+//	winrt::com_ptr<ID3D12Fence> fence;
+//	winrt::check_hresult(d3d12Device->CreateFence(0, D3D12_FENCE_FLAG_NONE, winrt::guid_of<ID3D12Fence>(), fence.put_void()));
+//	return std::make_shared<D3D12Fence>(fence, d3d12CommandQueue);
+//}
+
+inline std::shared_ptr<D3D11Fence> CreateD3D11Fence(winrt::com_ptr<ID3D11Device5> const& d3d11Device, winrt::com_ptr<ID3D11DeviceContext4> const& d3d11Context)
+{
+	winrt::com_ptr<ID3D11Fence> fence;
+	winrt::check_hresult(d3d11Device->CreateFence(0, D3D11_FENCE_FLAG_NONE, winrt::guid_of<ID3D11Fence>(), fence.put_void()));
+	return std::make_shared<D3D11Fence>(fence, d3d11Context);
+}

--- a/ImageViewerNative/ImageViewerNative.def
+++ b/ImageViewerNative/ImageViewerNative.def
@@ -1,0 +1,3 @@
+﻿EXPORTS
+DllCanUnloadNow = WINRT_CanUnloadNow                    PRIVATE
+DllGetActivationFactory = WINRT_GetActivationFactory    PRIVATE

--- a/ImageViewerNative/ImageViewerNative.idl
+++ b/ImageViewerNative/ImageViewerNative.idl
@@ -1,0 +1,17 @@
+namespace ImageViewerNative
+{
+    runtimeclass VideoFrameArgs
+    {
+        Windows.Graphics.DirectX.Direct3D11.IDirect3DSurface Surface { get; };
+        Windows.Foundation.TimeSpan Timestamp { get; };
+        UInt64 FrameId { get; };
+    }
+
+    runtimeclass VideoFrameExtractor
+    {
+        static void ExtractFromStream(
+            Windows.Storage.Streams.IRandomAccessStream stream,
+            Windows.Graphics.DirectX.Direct3D11.IDirect3DDevice device,
+            Windows.Foundation.EventHandler<VideoFrameArgs> callback);
+    }
+}

--- a/ImageViewerNative/ImageViewerNative.vcxproj
+++ b/ImageViewerNative/ImageViewerNative.vcxproj
@@ -130,6 +130,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Fence.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="VideoDecoder.h" />
     <ClInclude Include="VideoDecoderDevice.h" />

--- a/ImageViewerNative/ImageViewerNative.vcxproj
+++ b/ImageViewerNative/ImageViewerNative.vcxproj
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{ec7bc29a-fbba-4a3b-abcb-9bba4dc76ee3}</ProjectGuid>
+    <ProjectName>ImageViewerNative</ProjectName>
+    <RootNamespace>ImageViewerNative</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.19041.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="PropertySheet.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <PreprocessorDefinitions>_WINRT_DLL;WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+      <ModuleDefinitionFile>ImageViewerNative.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mfuuid.lib;mfreadwrite.lib;wmcodecdspuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="VideoDecoder.h" />
+    <ClInclude Include="VideoDecoderDevice.h" />
+    <ClInclude Include="VideoDecoderProcessor.h" />
+    <ClInclude Include="VideoFrameArgs.h" />
+    <ClInclude Include="VideoFrameExtractor.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="VideoDecoder.cpp" />
+    <ClCompile Include="VideoDecoderDevice.cpp" />
+    <ClCompile Include="VideoDecoderProcessor.cpp" />
+    <ClCompile Include="VideoFrameArgs.cpp" />
+    <ClCompile Include="VideoFrameExtractor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ImageViewerNative.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="ImageViewerNative.idl" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\packages\robmikh.common.0.0.22-beta\build\native\robmikh.common.targets" Condition="Exists('..\packages\robmikh.common.0.0.22-beta\build\native\robmikh.common.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.230824.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\packages\robmikh.common.0.0.22-beta\build\native\robmikh.common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\robmikh.common.0.0.22-beta\build\native\robmikh.common.targets'))" />
+  </Target>
+</Project>

--- a/ImageViewerNative/ImageViewerNative.vcxproj.filters
+++ b/ImageViewerNative/ImageViewerNative.vcxproj.filters
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
-    <ClCompile Include="Class.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="VideoFrameArgs.cpp" />
     <ClCompile Include="VideoFrameExtractor.cpp" />
@@ -26,6 +25,7 @@
     <ClInclude Include="VideoDecoder.h" />
     <ClInclude Include="VideoDecoderDevice.h" />
     <ClInclude Include="VideoDecoderProcessor.h" />
+    <ClInclude Include="Fence.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ImageViewerNative.def" />
@@ -36,5 +36,8 @@
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ImageViewerNative.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
 </Project>

--- a/ImageViewerNative/ImageViewerNative.vcxproj.filters
+++ b/ImageViewerNative/ImageViewerNative.vcxproj.filters
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resources">
+      <UniqueIdentifier>accd3aa8-1ba0-4223-9bbe-0c431709210b</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{926ab91d-31b4-48c3-b9a4-e681349f27f0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="Class.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="VideoFrameArgs.cpp" />
+    <ClCompile Include="VideoFrameExtractor.cpp" />
+    <ClCompile Include="VideoDecoder.cpp" />
+    <ClCompile Include="VideoDecoderDevice.cpp" />
+    <ClCompile Include="VideoDecoderProcessor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="VideoFrameArgs.h" />
+    <ClInclude Include="VideoFrameExtractor.h" />
+    <ClInclude Include="VideoDecoder.h" />
+    <ClInclude Include="VideoDecoderDevice.h" />
+    <ClInclude Include="VideoDecoderProcessor.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ImageViewerNative.def" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="ImageViewerNative.idl" />
+  </ItemGroup>
+</Project>

--- a/ImageViewerNative/PropertySheet.props
+++ b/ImageViewerNative/PropertySheet.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <!--
+    To customize common C++/WinRT project properties: 
+    * right-click the project node
+    * expand the Common Properties item
+    * select the C++/WinRT property page
+
+    For more advanced scenarios, and complete documentation, please see:
+    https://github.com/Microsoft/cppwinrt/tree/master/nuget 
+    -->
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/ImageViewerNative/VideoDecoder.cpp
+++ b/ImageViewerNative/VideoDecoder.cpp
@@ -1,0 +1,422 @@
+﻿#include "pch.h"
+#include "VideoDecoder.h"
+#include "VideoDecoderDevice.h"
+
+namespace winrt
+{
+    using namespace Windows::Foundation;
+    using namespace Windows::Graphics;
+    using namespace Windows::Storage::Streams;
+}
+
+namespace util
+{
+    using namespace robmikh::common::uwp;
+}
+
+inline winrt::com_ptr<ID3D11Texture2D> CreateNV12Texture(
+    winrt::com_ptr<ID3D11Device> const& d3dDevice,
+    winrt::SizeInt32 const& resolution,
+    bool staging)
+{
+    winrt::com_ptr<ID3D11Texture2D> texture;
+    D3D11_TEXTURE2D_DESC desc = {};
+    desc.Width = resolution.Width;
+    desc.Height = resolution.Height;
+    desc.ArraySize = 1;
+    desc.MipLevels = 1;
+    desc.Format = DXGI_FORMAT_NV12;
+    desc.SampleDesc.Count = 1;
+    desc.Usage = staging ? D3D11_USAGE_STAGING : D3D11_USAGE_DEFAULT;
+    desc.CPUAccessFlags = staging ? D3D11_CPU_ACCESS_WRITE : 0;
+    desc.BindFlags = staging ? 0 : D3D11_BIND_SHADER_RESOURCE;
+    winrt::check_hresult(d3dDevice->CreateTexture2D(&desc, nullptr, texture.put()));
+    return texture;
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/medfound/media-type-debugging-code
+float OffsetToFloat(const MFOffset& offset)
+{
+    return offset.value + (static_cast<float>(offset.fract) / 65536.0f);
+}
+
+VideoDecoder::VideoDecoder(
+    std::shared_ptr<VideoDecoderDevice> const& decoderDevice,
+    winrt::com_ptr<ID3D11Device> const& d3dDevice,
+    winrt::com_ptr<IMFMediaType> const& inputMediaType)
+{
+    uint32_t width = 0;
+    uint32_t height = 0;
+    winrt::check_hresult(MFGetAttributeSize(inputMediaType.get(), MF_MT_FRAME_SIZE, &width, &height));
+    uint32_t frameRateNumerator = 0;
+    uint32_t frameRateDenominator = 0;
+    winrt::check_hresult(MFGetAttributeRatio(inputMediaType.get(), MF_MT_FRAME_RATE, &frameRateNumerator, &frameRateDenominator));
+    GUID videoSubtype = {};
+    winrt::check_hresult(inputMediaType->GetGUID(MF_MT_SUBTYPE, &videoSubtype));
+
+    m_inputResolution = { static_cast<int32_t>(width), static_cast<int32_t>(height) };
+    m_outputResolution = m_inputResolution;
+    m_frameRateNumerator = frameRateNumerator;
+    m_frameRateDenominator = frameRateDenominator;
+
+    m_transform = decoderDevice->CreateTransform();
+    m_d3dDevice = d3dDevice;
+    m_d3dDevice->GetImmediateContext(m_d3dContext.put());
+
+    m_d3dMultithread = m_d3dDevice.as<ID3D11Multithread>();
+    m_d3dMultithread->SetMultithreadProtected(true);
+
+    // Create MF device manager
+    winrt::check_hresult(MFCreateDXGIDeviceManager(&m_deviceManagerResetToken, m_mediaDeviceManager.put()));
+    winrt::check_hresult(m_mediaDeviceManager->ResetDevice(m_d3dDevice.get(), m_deviceManagerResetToken));
+
+    // Setup MFTransform
+    winrt::com_ptr<IMFAttributes> attributes;
+    winrt::check_hresult(m_transform->GetAttributes(attributes.put()));
+    winrt::check_hresult(attributes->SetUINT32(MF_LOW_LATENCY, 1));
+    // MPEG2 specific
+    if (videoSubtype == MFVideoFormat_MPEG2)
+    {
+        winrt::check_hresult(attributes->SetUINT32(CODECAPI_AVDecVideoAcceleration_MPEG2, 1));
+        winrt::check_hresult(attributes->SetUINT32(CODECAPI_AVLowLatencyMode, 1));
+    }
+
+    DWORD numInputStreams = 0;
+    DWORD numOutputStreams = 0;
+    winrt::check_hresult(m_transform->GetStreamCount(&numInputStreams, &numOutputStreams));
+    std::vector<DWORD> inputStreamIds(numInputStreams, 0);
+    std::vector<DWORD> outputSteamIds(numOutputStreams, 0);
+    {
+        auto hr = m_transform->GetStreamIDs(numInputStreams, inputStreamIds.data(), numOutputStreams, outputSteamIds.data());
+        // https://docs.microsoft.com/en-us/windows/win32/api/mftransform/nf-mftransform-imftransform-getstreamids
+        // This method can return E_NOTIMPL if both of the following conditions are true:
+        //   * The transform has a fixed number of streams.
+        //   * The streams are numbered consecutively from 0 to n � 1, where n is the
+        //     number of input streams or output streams. In other words, the first 
+        //     input stream is 0, the second is 1, and so on; and the first output 
+        //     stream is 0, the second is 1, and so on. 
+        if (hr == E_NOTIMPL)
+        {
+            for (auto i = 0; i < inputStreamIds.size(); i++)
+            {
+                inputStreamIds[i] = i;
+            }
+            for (auto i = 0; i < outputSteamIds.size(); i++)
+            {
+                outputSteamIds[i] = i;
+            }
+        }
+        else
+        {
+            winrt::check_hresult(hr);
+        }
+    }
+    m_inputStreamId = inputStreamIds[0];
+    m_outputStreamId = outputSteamIds[0];
+
+    winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_SET_D3D_MANAGER, reinterpret_cast<ULONG_PTR>(m_mediaDeviceManager.get())));
+
+    winrt::check_hresult(m_transform->SetInputType(m_inputStreamId, inputMediaType.get(), 0));
+
+    MFT_REGISTER_TYPE_INFO outputInfo = { MFMediaType_Video, MFVideoFormat_NV12 };
+    winrt::com_ptr<IMFMediaType> outputType;
+    std::optional<D3D11_BOX> outputBox = std::nullopt;
+    {
+        auto count = 0;
+        for (count = 0;; count++)
+        {
+            outputType = nullptr;
+            outputBox = std::nullopt;
+            m_fullOutputResolution = m_outputResolution;
+            auto hr = m_transform->GetOutputAvailableType(m_outputStreamId, count, outputType.put());
+            if (hr == MF_E_NO_MORE_TYPES)
+            {
+                break;
+            }
+            //winrt::check_hresult(LogMediaType(outputType.get()));
+            //OutputDebugStringW(L"\n");
+            winrt::check_hresult(hr);
+            winrt::check_hresult(outputType->SetGUID(MF_MT_MAJOR_TYPE, outputInfo.guidMajorType));
+            winrt::check_hresult(outputType->SetGUID(MF_MT_SUBTYPE, outputInfo.guidSubtype));
+            // The frame size may be larger than the reported video resolution
+            uint32_t outputWidth = 0;
+            uint32_t outputHeight = 0;
+            winrt::check_hresult(MFGetAttributeSize(outputType.get(), MF_MT_FRAME_SIZE, &outputWidth, &outputHeight));
+            if (!(outputWidth == static_cast<uint32_t>(m_outputResolution.Width) &&
+                  outputHeight == static_cast<uint32_t>(m_outputResolution.Height)) &&
+                outputWidth >= static_cast<uint32_t>(m_outputResolution.Width) &&
+                outputHeight >= static_cast<uint32_t>(m_outputResolution.Height))
+            {
+                // Let's figure out the bounds of the valid pixels in the frame
+                MFVideoArea videoArea = {};
+                uint32_t blobSize = 0;
+                winrt::check_hresult(outputType->GetBlob(MF_MT_MINIMUM_DISPLAY_APERTURE, reinterpret_cast<uint8_t*>(&videoArea), sizeof(videoArea), &blobSize));
+                auto x = static_cast<uint32_t>(OffsetToFloat(videoArea.OffsetX));
+                auto y = static_cast<uint32_t>(OffsetToFloat(videoArea.OffsetY));
+                auto videoAreaWidth = static_cast<uint32_t>(videoArea.Area.cx);
+                auto videoAreaHeight = static_cast<uint32_t>(videoArea.Area.cy);
+                outputBox = std::optional(D3D11_BOX{ x, y, 0, x + videoAreaWidth, y + videoAreaHeight, 1 });
+                m_fullOutputResolution = { static_cast<int>(outputWidth), static_cast<int>(outputHeight) };
+            }
+            // Otherwise test our luck setting the frame size
+            else
+            {
+                winrt::check_hresult(MFSetAttributeSize(outputType.get(), MF_MT_FRAME_SIZE, m_outputResolution.Width, m_outputResolution.Height));
+            }
+            winrt::check_hresult(MFSetAttributeRatio(outputType.get(), MF_MT_FRAME_RATE, m_frameRateNumerator, m_frameRateDenominator));
+            winrt::check_hresult(outputType->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, 1));
+            winrt::check_hresult(outputType->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
+            hr = m_transform->SetOutputType(m_outputStreamId, outputType.get(), MFT_SET_TYPE_TEST_ONLY);
+            if (hr == MF_E_INVALIDMEDIATYPE)
+            {
+                continue;
+            }
+            winrt::check_hresult(hr);
+            break;
+        }
+        if (outputType == nullptr)
+        {
+            throw std::runtime_error("No suitable input type found");
+        }
+        winrt::check_hresult(m_transform->SetOutputType(m_outputStreamId, outputType.get(), 0));
+        m_outputBox = outputBox;
+    }
+
+    StartDecode();
+}
+
+VideoDecoder::~VideoDecoder()
+{
+    StopDecode();
+}
+
+HRESULT VideoDecoder::ProcessInputSample(VideoDecoderInputSample const& inputSample)
+{
+    auto mfSample = CreateMFSample(inputSample);
+    return ProcessInputSample(mfSample);
+}
+
+HRESULT VideoDecoder::ProcessInputSample(winrt::com_ptr<IMFSample> const& mfSample)
+{
+    if (m_started.load())
+    {
+        return ProcessInput(mfSample);
+    }
+    throw std::runtime_error("Must start decoder!");
+}
+
+SampleProcessResult VideoDecoder::ProcessOutputSample(winrt::com_ptr<ID3D11Texture2D>& result, int64_t& timeStamp)
+{
+    return ProcessOutput(result, timeStamp);
+}
+
+void VideoDecoder::StartDecode()
+{
+    bool expected = false;
+    if (m_started.compare_exchange_strong(expected, true))
+    {
+        winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0));
+        winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0));
+        winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0));
+    }
+}
+
+void VideoDecoder::StopDecode()
+{
+    bool expected = true;
+    if (m_started.compare_exchange_strong(expected, false))
+    {
+        winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0));
+        winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_NOTIFY_END_STREAMING, 0));
+        winrt::check_hresult(m_transform->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0));
+    }
+}
+
+void VideoDecoder::OnStreamChange()
+{
+    MFT_REGISTER_TYPE_INFO outputInfo = { MFMediaType_Video, MFVideoFormat_NV12 };
+    winrt::com_ptr<IMFMediaType> outputType;
+    std::optional<D3D11_BOX> outputBox = std::nullopt;
+    {
+        auto count = 0;
+        for (count = 0;; count++)
+        {
+            outputType = nullptr;
+            outputBox = std::nullopt;
+            m_fullOutputResolution = m_outputResolution;
+            HRESULT hr = m_transform->GetOutputAvailableType(m_outputStreamId, count, outputType.put());
+            if (hr == MF_E_NO_MORE_TYPES)
+            {
+                break;
+            }
+            //winrt::check_hresult(LogMediaType(outputType.get()));
+            //OutputDebugStringW(L"\n");
+            winrt::check_hresult(hr);
+            winrt::check_hresult(outputType->SetGUID(MF_MT_MAJOR_TYPE, outputInfo.guidMajorType));
+            winrt::check_hresult(outputType->SetGUID(MF_MT_SUBTYPE, outputInfo.guidSubtype));
+            // The frame size may be larger than the reported video resolution
+            uint32_t outputWidth = 0;
+            uint32_t outputHeight = 0;
+            winrt::check_hresult(MFGetAttributeSize(outputType.get(), MF_MT_FRAME_SIZE, &outputWidth, &outputHeight));
+            if (!(outputWidth == static_cast<uint32_t>(m_outputResolution.Width) &&
+                outputHeight == static_cast<uint32_t>(m_outputResolution.Height)) &&
+                outputWidth >= static_cast<uint32_t>(m_outputResolution.Width) &&
+                outputHeight >= static_cast<uint32_t>(m_outputResolution.Height))
+            {
+                // Let's figure out the bounds of the valid pixels in the frame
+                MFVideoArea videoArea = {};
+                uint32_t blobSize = 0;
+                winrt::check_hresult(outputType->GetBlob(MF_MT_MINIMUM_DISPLAY_APERTURE, reinterpret_cast<uint8_t*>(&videoArea), sizeof(videoArea), &blobSize));
+                auto x = static_cast<uint32_t>(OffsetToFloat(videoArea.OffsetX));
+                auto y = static_cast<uint32_t>(OffsetToFloat(videoArea.OffsetY));
+                auto width = static_cast<uint32_t>(videoArea.Area.cx);
+                auto height = static_cast<uint32_t>(videoArea.Area.cy);
+                outputBox = std::optional(D3D11_BOX{ x, y, 0, x + width, y + height, 1 });
+                m_fullOutputResolution = { static_cast<int>(outputWidth), static_cast<int>(outputHeight) };
+            }
+            // Otherwise test our luck setting the frame size
+            else
+            {
+                winrt::check_hresult(MFSetAttributeSize(outputType.get(), MF_MT_FRAME_SIZE, m_outputResolution.Width, m_outputResolution.Height));
+            }
+            winrt::check_hresult(MFSetAttributeRatio(outputType.get(), MF_MT_FRAME_RATE, m_frameRateNumerator, m_frameRateDenominator));
+            winrt::check_hresult(outputType->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, 1));
+            winrt::check_hresult(outputType->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
+            hr = m_transform->SetOutputType(m_outputStreamId, outputType.get(), MFT_SET_TYPE_TEST_ONLY);
+            if (hr == MF_E_INVALIDMEDIATYPE)
+            {
+                continue;
+            }
+            winrt::check_hresult(hr);
+            break;
+        }
+        if (outputType == nullptr)
+        {
+            throw std::runtime_error("No suitable input type found");
+        }
+        winrt::check_hresult(m_transform->SetOutputType(m_outputStreamId, outputType.get(), 0));
+        m_outputBox = outputBox;
+    }
+    winrt::com_ptr<IMFAttributes> attributes;
+    winrt::check_hresult(m_transform->GetAttributes(attributes.put()));
+    winrt::check_hresult(attributes->SetUINT32(MF_LOW_LATENCY, 1));
+}
+
+void VideoDecoder::EnsureOutputTexture()
+{
+    if (m_outputTexture == nullptr)
+    {
+        m_outputTexture = CreateNV12Texture(m_d3dDevice, m_fullOutputResolution, false);
+    }
+}
+
+void VideoDecoder::EnsureStagingTexture()
+{
+    if (m_stagingTexture == nullptr)
+    {
+        m_stagingTexture = CreateNV12Texture(m_d3dDevice, m_fullOutputResolution, true);
+    }
+}
+
+winrt::com_ptr<IMFSample> VideoDecoder::CreateMFSample(VideoDecoderInputSample const& inputSample)
+{
+    auto buffer = inputSample.Buffer;
+    auto bufferLength = buffer.Length();
+    winrt::com_ptr<IMFMediaBuffer> inputBuffer;
+    winrt::check_hresult(MFCreateMemoryBuffer(bufferLength, inputBuffer.put()));
+    {
+        byte* bytes = nullptr;
+        auto byteAccess = buffer.as<::Windows::Storage::Streams::IBufferByteAccess>();
+        winrt::check_hresult(byteAccess->Buffer(&bytes));
+
+        auto guard = util::MediaBufferGuard(inputBuffer);
+        auto info = guard.Info();
+
+        memcpy_s(reinterpret_cast<void*>(info.Bits), info.MaxLength, reinterpret_cast<void*>(bytes), bufferLength);
+    }
+    winrt::check_hresult(inputBuffer->SetCurrentLength(bufferLength));
+    winrt::com_ptr<IMFSample> mfSample;
+    winrt::check_hresult(MFCreateSample(mfSample.put()));
+    winrt::check_hresult(mfSample->AddBuffer(inputBuffer.get()));
+    winrt::check_hresult(mfSample->SetSampleTime(inputSample.TimeStamp));
+    return mfSample;
+}
+
+HRESULT VideoDecoder::ProcessInput(winrt::com_ptr<IMFSample> const& mfSample)
+{
+    RETURN_IF_FAILED(m_transform->ProcessInput(m_inputStreamId, mfSample.get(), 0));
+    return S_OK;
+}
+
+SampleProcessResult VideoDecoder::ProcessOutput(winrt::com_ptr<ID3D11Texture2D>& result, int64_t& timeStamp)
+{
+    winrt::com_ptr<ID3D11Texture2D> resultTexture;
+
+    DWORD status = 0;
+    MFT_OUTPUT_DATA_BUFFER outputBuffer = {};
+    outputBuffer.dwStreamID = m_outputStreamId;
+
+    HRESULT hr = m_transform->ProcessOutput(0, 1, &outputBuffer, &status);
+    if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT)
+    {
+        return SampleProcessResult::NeedsMoreInput;
+    }
+    else if (hr == MF_E_TRANSFORM_STREAM_CHANGE)
+    {
+        OnStreamChange();
+        return SampleProcessResult::StreamChanged;
+    }
+    winrt::check_hresult(hr);
+
+    winrt::com_ptr<IMFSample> sample;
+    sample.attach(outputBuffer.pSample);
+    winrt::com_ptr<IMFCollection> events;
+    events.attach(outputBuffer.pEvents);
+
+    winrt::com_ptr<IMFMediaBuffer> mfBuffer;
+    winrt::check_hresult(sample->GetBufferByIndex(0, mfBuffer.put()));
+
+    int64_t sampleTime = 0;
+    winrt::check_hresult(sample->GetSampleTime(&sampleTime));
+    timeStamp = sampleTime;
+
+    if (auto dxgiBuffer = mfBuffer.try_as<IMFDXGIBuffer>())
+    {
+        util::D3D11DeviceLock lock(m_d3dMultithread.get());
+        EnsureOutputTexture();
+
+        winrt::com_ptr<ID3D11Texture2D> sampleTexture;
+        winrt::check_hresult(dxgiBuffer->GetResource(winrt::guid_of<ID3D11Texture2D>(), sampleTexture.put_void()));
+        uint32_t subresourceIndex = 0;
+        winrt::check_hresult(dxgiBuffer->GetSubresourceIndex(&subresourceIndex));
+        m_d3dContext->CopySubresourceRegion(m_outputTexture.get(), 0, 0, 0, 0, sampleTexture.get(), subresourceIndex, nullptr);
+        resultTexture = m_outputTexture;
+    }
+    else
+    {
+        {
+            util::D3D11DeviceLock lock(m_d3dMultithread.get());
+            EnsureStagingTexture();
+
+            auto guard = util::MediaBufferGuard(mfBuffer);
+            auto info = guard.Info();
+
+            D3D11_TEXTURE2D_DESC desc = {};
+            m_stagingTexture->GetDesc(&desc);
+
+            D3D11_MAPPED_SUBRESOURCE mapped = {};
+            winrt::check_hresult(m_d3dContext->Map(m_stagingTexture.get(), 0, D3D11_MAP_WRITE, 0, &mapped));
+            auto scope = wil::scope_exit([=]()
+                {
+                    m_d3dContext->Unmap(m_stagingTexture.get(), 0);
+                });
+
+            memcpy_s(mapped.pData, info.CurrentLength, reinterpret_cast<void*>(info.Bits), info.CurrentLength);
+        }
+        resultTexture = m_stagingTexture;
+    }
+
+    assert(resultTexture != nullptr);
+    result.copy_from(resultTexture.get());
+    return SampleProcessResult::Success;
+}

--- a/ImageViewerNative/VideoDecoder.cpp
+++ b/ImageViewerNative/VideoDecoder.cpp
@@ -133,8 +133,6 @@ VideoDecoder::VideoDecoder(
             {
                 break;
             }
-            //winrt::check_hresult(LogMediaType(outputType.get()));
-            //OutputDebugStringW(L"\n");
             winrt::check_hresult(hr);
             winrt::check_hresult(outputType->SetGUID(MF_MT_MAJOR_TYPE, outputInfo.guidMajorType));
             winrt::check_hresult(outputType->SetGUID(MF_MT_SUBTYPE, outputInfo.guidSubtype));
@@ -249,8 +247,6 @@ void VideoDecoder::OnStreamChange()
             {
                 break;
             }
-            //winrt::check_hresult(LogMediaType(outputType.get()));
-            //OutputDebugStringW(L"\n");
             winrt::check_hresult(hr);
             winrt::check_hresult(outputType->SetGUID(MF_MT_MAJOR_TYPE, outputInfo.guidMajorType));
             winrt::check_hresult(outputType->SetGUID(MF_MT_SUBTYPE, outputInfo.guidSubtype));

--- a/ImageViewerNative/VideoDecoder.h
+++ b/ImageViewerNative/VideoDecoder.h
@@ -1,0 +1,67 @@
+#pragma once
+
+class VideoDecoderDevice;
+
+struct VideoDecoderInputSample
+{
+    LONGLONG TimeStamp;
+    winrt::Windows::Storage::Streams::IBuffer Buffer{ nullptr };
+};
+
+enum SampleProcessResult
+{
+    Success,
+    NeedsMoreInput,
+    StreamChanged,
+};
+
+class VideoDecoder
+{
+public:
+    VideoDecoder(
+        std::shared_ptr<VideoDecoderDevice> const& decoderDevice,
+        winrt::com_ptr<ID3D11Device> const& d3dDevice,
+        winrt::com_ptr<IMFMediaType> const& inputMediaType);
+    ~VideoDecoder();
+
+    winrt::com_ptr<IMFMediaType> const& OutputType() { return m_outputType; }
+    HRESULT ProcessInputSample(VideoDecoderInputSample const& inputSample);
+    HRESULT ProcessInputSample(winrt::com_ptr<IMFSample> const& mfSample);
+    SampleProcessResult ProcessOutputSample(winrt::com_ptr<ID3D11Texture2D>& result, int64_t& timeStamp);
+    std::optional<D3D11_BOX> const& OutputBox() { return m_outputBox; }
+
+private:
+    void StartDecode();
+    void StopDecode();
+    void OnStreamChange();
+    void EnsureOutputTexture();
+    void EnsureStagingTexture();
+    winrt::com_ptr<IMFSample> CreateMFSample(VideoDecoderInputSample const& inputSample);
+    HRESULT ProcessInput(winrt::com_ptr<IMFSample> const& mfSample);
+    SampleProcessResult ProcessOutput(winrt::com_ptr<ID3D11Texture2D>& result, int64_t& timeStamp);
+
+private:
+    winrt::com_ptr<ID3D11Device> m_d3dDevice;
+    winrt::com_ptr<ID3D11DeviceContext> m_d3dContext;
+    winrt::com_ptr<ID3D11Multithread> m_d3dMultithread;
+    winrt::com_ptr<IMFDXGIDeviceManager> m_mediaDeviceManager;
+    uint32_t m_deviceManagerResetToken = 0;
+
+    winrt::com_ptr<IMFTransform> m_transform;
+    DWORD m_inputStreamId = 0;
+    DWORD m_outputStreamId = 0;
+    winrt::com_ptr<IMFMediaType> m_outputType;
+
+    std::atomic<bool> m_started = false;
+    winrt::Windows::Graphics::SizeInt32 m_inputResolution = { 0, 0 };
+    winrt::Windows::Graphics::SizeInt32 m_outputResolution = { 0, 0 };
+
+    winrt::com_ptr<ID3D11Texture2D> m_stagingTexture;
+    winrt::com_ptr<ID3D11Texture2D> m_outputTexture;
+
+    uint32_t m_frameRateNumerator = 0;
+    uint32_t m_frameRateDenominator = 0;
+    
+    winrt::Windows::Graphics::SizeInt32 m_fullOutputResolution = { 0, 0 };
+    std::optional<D3D11_BOX> m_outputBox = std::nullopt;
+};

--- a/ImageViewerNative/VideoDecoderDevice.cpp
+++ b/ImageViewerNative/VideoDecoderDevice.cpp
@@ -1,0 +1,51 @@
+﻿#include "pch.h"
+#include "VideoDecoderDevice.h"
+
+namespace util
+{
+    using namespace robmikh::common::uwp;
+}
+
+std::vector<std::shared_ptr<VideoDecoderDevice>> VideoDecoderDevice::EnumerateAll(winrt::guid const& inputSubType)
+{
+    std::vector<std::shared_ptr<VideoDecoderDevice>> encoders;
+
+    MFT_REGISTER_TYPE_INFO inputType = { MFMediaType_Video, inputSubType };
+    MFT_REGISTER_TYPE_INFO outputType = { MFMediaType_Video,  MFVideoFormat_NV12 };
+    auto transformSources = util::EnumerateMFTs(
+        MFT_CATEGORY_VIDEO_DECODER,
+        MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_TRANSCODE_ONLY | MFT_ENUM_FLAG_SORTANDFILTER,
+        &inputType,
+        &outputType);
+
+    for (auto transformSource : transformSources)
+    {
+        auto encoder = std::make_shared<VideoDecoderDevice>(transformSource);
+        encoders.push_back(encoder);
+    }
+
+    return encoders;
+}
+
+VideoDecoderDevice::VideoDecoderDevice(winrt::com_ptr<IMFActivate> const& transformSource)
+{
+    std::wstring friendlyName;
+    if (auto name = util::GetStringAttribute(transformSource, MFT_FRIENDLY_NAME_Attribute))
+    {
+        friendlyName = name.value();
+    }
+    else
+    {
+        friendlyName = L"Unknown";
+    }
+
+    m_transformSource = transformSource;
+    m_name = friendlyName;
+}
+
+winrt::com_ptr<IMFTransform> VideoDecoderDevice::CreateTransform()
+{
+    winrt::com_ptr<IMFTransform> transform;
+    winrt::check_hresult(m_transformSource->ActivateObject(winrt::guid_of<IMFTransform>(), transform.put_void()));
+    return transform;
+}

--- a/ImageViewerNative/VideoDecoderDevice.h
+++ b/ImageViewerNative/VideoDecoderDevice.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class VideoDecoderDevice
+{
+public:
+    static std::vector<std::shared_ptr<VideoDecoderDevice>> EnumerateAll(winrt::guid const& inputSubType);
+
+    VideoDecoderDevice(winrt::com_ptr<IMFActivate> const& transformSource);
+
+    std::wstring const& Name() { return m_name; }
+
+    winrt::com_ptr<IMFTransform> CreateTransform();
+
+private:
+    winrt::com_ptr<IMFActivate> m_transformSource;
+    std::wstring m_name;
+};

--- a/ImageViewerNative/VideoDecoderProcessor.cpp
+++ b/ImageViewerNative/VideoDecoderProcessor.cpp
@@ -1,0 +1,149 @@
+#include "pch.h"
+#include "VideoDecoderProcessor.h"
+
+namespace winrt
+{
+    using namespace Windows::Foundation;
+    using namespace Windows::Foundation::Numerics;
+    using namespace Windows::Graphics;
+}
+
+//float ComputeScaleFactor(winrt::float2 const outputSize, winrt::float2 const inputSize)
+//{
+//    auto outputRatio = outputSize.x / outputSize.y;
+//    auto inputRatio = inputSize.x / inputSize.y;
+//
+//    auto scaleFactor = outputSize.x / inputSize.x;
+//    if (outputRatio > inputRatio)
+//    {
+//        scaleFactor = outputSize.y / inputSize.y;
+//    }
+//
+//    return scaleFactor;
+//}
+
+//winrt::RectInt32 ComputeDestRect(winrt::SizeInt32 const outputSize, winrt::SizeInt32 const inputSize)
+//{
+//    auto scale = ComputeScaleFactor({ (float)outputSize.Width, (float)outputSize.Height }, { (float)inputSize.Width, (float)inputSize.Height });
+//    winrt::SizeInt32 newSize{ (int)(inputSize.Width * scale), (int)(inputSize.Height * scale) };
+//    auto offsetX = 0;
+//    auto offsetY = 0;
+//    if (newSize.Width != outputSize.Width)
+//    {
+//        offsetX = (outputSize.Width - newSize.Width) / 2;
+//    }
+//    if (newSize.Height != outputSize.Height)
+//    {
+//        offsetY = (outputSize.Height - newSize.Height) / 2;
+//    }
+//    return winrt::RectInt32{
+//        offsetX,
+//        offsetY,
+//        newSize.Width,
+//        newSize.Height
+//    };
+//}
+
+VideoDecoderProcessor::VideoDecoderProcessor(
+    winrt::com_ptr<ID3D11Device> const& d3dDevice,
+    DXGI_FORMAT const inputFormat,
+    winrt::SizeInt32 const& inputSize,
+    DXGI_FORMAT const outputFormat,
+    winrt::SizeInt32 const& outputSize)
+{
+    m_d3dDevice = d3dDevice;
+    m_d3dDevice->GetImmediateContext(m_d3dContext.put());
+
+    // Setup video conversion
+    m_videoDevice = m_d3dDevice.as<ID3D11VideoDevice>();
+    m_videoContext = m_d3dContext.as<ID3D11VideoContext>();
+
+    winrt::com_ptr<ID3D11VideoProcessorEnumerator> videoEnum;
+    D3D11_VIDEO_PROCESSOR_CONTENT_DESC videoDesc = {};
+    videoDesc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE;
+    videoDesc.InputFrameRate.Numerator = 60;
+    videoDesc.InputFrameRate.Denominator = 1;
+    videoDesc.InputWidth = inputSize.Width;
+    videoDesc.InputHeight = inputSize.Height;
+    videoDesc.OutputFrameRate.Numerator = 60;
+    videoDesc.OutputFrameRate.Denominator = 1;
+    videoDesc.OutputWidth = outputSize.Width;
+    videoDesc.OutputHeight = outputSize.Height;
+    videoDesc.Usage = D3D11_VIDEO_USAGE_OPTIMAL_QUALITY;
+    winrt::check_hresult(m_videoDevice->CreateVideoProcessorEnumerator(&videoDesc, videoEnum.put()));
+
+    winrt::check_hresult(m_videoDevice->CreateVideoProcessor(videoEnum.get(), 0, m_videoProcessor.put()));
+
+    D3D11_VIDEO_PROCESSOR_COLOR_SPACE colorSpace = {};
+    colorSpace.Usage = 1; // Video processing
+    colorSpace.Nominal_Range = D3D11_VIDEO_PROCESSOR_NOMINAL_RANGE_0_255;
+    m_videoContext->VideoProcessorSetOutputColorSpace(m_videoProcessor.get(), &colorSpace);
+    colorSpace.Nominal_Range = D3D11_VIDEO_PROCESSOR_NOMINAL_RANGE_16_235;
+    m_videoContext->VideoProcessorSetStreamColorSpace(m_videoProcessor.get(), 0, &colorSpace);
+
+    // If the input and output resolutions don't match, setup the
+    // video processor to preserve the aspect ratio when scaling.
+    //if (inputSize.Width != outputSize.Width || inputSize.Height != outputSize.Height)
+    //{
+    //    auto destRect = ComputeDestRect(outputSize, inputSize);
+    //    auto rect = RECT{
+    //        destRect.X,
+    //        destRect.Y,
+    //        destRect.X + destRect.Width,
+    //        destRect.Y + destRect.Height,
+    //    };
+    //    m_videoContext->VideoProcessorSetStreamDestRect(m_videoProcessor.get(), 0, true, &rect);
+    //}
+
+    D3D11_TEXTURE2D_DESC textureDesc = {};
+    textureDesc.Width = outputSize.Width;
+    textureDesc.Height = outputSize.Height;
+    textureDesc.ArraySize = 1;
+    textureDesc.MipLevels = 1;
+    textureDesc.Format = outputFormat;
+    textureDesc.SampleDesc.Count = 1;
+    textureDesc.Usage = D3D11_USAGE_DEFAULT;
+    textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET; // | D3D11_BIND_VIDEO_ENCODER;
+    winrt::check_hresult(m_d3dDevice->CreateTexture2D(&textureDesc, nullptr, m_videoOutputTexture.put()));
+
+    D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC outputViewDesc = {};
+    outputViewDesc.ViewDimension = D3D11_VPOV_DIMENSION_TEXTURE2D;
+    outputViewDesc.Texture2D.MipSlice = 0;
+    winrt::check_hresult(m_videoDevice->CreateVideoProcessorOutputView(m_videoOutputTexture.get(), videoEnum.get(), &outputViewDesc, m_videoOutput.put()));
+
+    textureDesc.Width = inputSize.Width;
+    textureDesc.Height = inputSize.Height;
+    textureDesc.Format = inputFormat;
+    textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    winrt::check_hresult(m_d3dDevice->CreateTexture2D(&textureDesc, nullptr, m_videoInputTexture.put()));
+
+    D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC inputViewDesc = {};
+    inputViewDesc.ViewDimension = D3D11_VPIV_DIMENSION_TEXTURE2D;
+    inputViewDesc.Texture2D.MipSlice = 0;
+    winrt::check_hresult(m_videoDevice->CreateVideoProcessorInputView(m_videoInputTexture.get(), videoEnum.get(), &inputViewDesc, m_videoInput.put()));
+}
+
+void VideoDecoderProcessor::ProcessTexture(winrt::com_ptr<ID3D11Texture2D> const& inputTexture, std::optional<D3D11_BOX> const& box)
+{
+    // The caller is responsible for making sure they give us a
+    // texture that matches the input size we were initialized with.
+
+    // Copy the texture to the video input texture
+    if (box.has_value())
+    {
+        auto d3dBox = box.value();
+        m_d3dContext->CopySubresourceRegion(m_videoInputTexture.get(), 0, 0, 0, 0, inputTexture.get(), 0, &d3dBox);
+    }
+    else
+    {
+        m_d3dContext->CopyResource(m_videoInputTexture.get(), inputTexture.get());
+    }
+
+    // Convert to NV12
+    D3D11_VIDEO_PROCESSOR_STREAM videoStream = {};
+    videoStream.Enable = true;
+    videoStream.OutputIndex = 0;
+    videoStream.InputFrameOrField = 0;
+    videoStream.pInputSurface = m_videoInput.get();
+    winrt::check_hresult(m_videoContext->VideoProcessorBlt(m_videoProcessor.get(), m_videoOutput.get(), 0, 1, &videoStream));
+}

--- a/ImageViewerNative/VideoDecoderProcessor.cpp
+++ b/ImageViewerNative/VideoDecoderProcessor.cpp
@@ -121,6 +121,10 @@ VideoDecoderProcessor::VideoDecoderProcessor(
     inputViewDesc.ViewDimension = D3D11_VPIV_DIMENSION_TEXTURE2D;
     inputViewDesc.Texture2D.MipSlice = 0;
     winrt::check_hresult(m_videoDevice->CreateVideoProcessorInputView(m_videoInputTexture.get(), videoEnum.get(), &inputViewDesc, m_videoInput.put()));
+
+    auto device5 = m_d3dDevice.as<ID3D11Device5>();
+    auto context4 = m_d3dContext.as<ID3D11DeviceContext4>();
+    m_fence = CreateD3D11Fence(device5, context4);
 }
 
 void VideoDecoderProcessor::ProcessTexture(winrt::com_ptr<ID3D11Texture2D> const& inputTexture, std::optional<D3D11_BOX> const& box)
@@ -146,4 +150,6 @@ void VideoDecoderProcessor::ProcessTexture(winrt::com_ptr<ID3D11Texture2D> const
     videoStream.InputFrameOrField = 0;
     videoStream.pInputSurface = m_videoInput.get();
     winrt::check_hresult(m_videoContext->VideoProcessorBlt(m_videoProcessor.get(), m_videoOutput.get(), 0, 1, &videoStream));
+
+    m_fence->WaitForGpu();
 }

--- a/ImageViewerNative/VideoDecoderProcessor.h
+++ b/ImageViewerNative/VideoDecoderProcessor.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Fence.h"
 
 class VideoDecoderProcessor
 {
@@ -25,4 +26,6 @@ private:
     winrt::com_ptr<ID3D11VideoProcessorOutputView> m_videoOutput;
     winrt::com_ptr<ID3D11Texture2D> m_videoInputTexture;
     winrt::com_ptr<ID3D11VideoProcessorInputView> m_videoInput;
+
+    std::shared_ptr<D3D11Fence> m_fence;
 };

--- a/ImageViewerNative/VideoDecoderProcessor.h
+++ b/ImageViewerNative/VideoDecoderProcessor.h
@@ -1,0 +1,28 @@
+#pragma once
+
+class VideoDecoderProcessor
+{
+public:
+    VideoDecoderProcessor(
+        winrt::com_ptr<ID3D11Device> const& d3dDevice,
+        DXGI_FORMAT const inputFormat,
+        winrt::Windows::Graphics::SizeInt32 const& inputSize,
+        DXGI_FORMAT const outputFormat,
+        winrt::Windows::Graphics::SizeInt32 const& outputSize);
+
+    winrt::com_ptr<ID3D11Texture2D> const& OutputTexture() { return m_videoOutputTexture; }
+
+    void ProcessTexture(winrt::com_ptr<ID3D11Texture2D> const& inputTexture, std::optional<D3D11_BOX> const& box);
+
+private:
+    winrt::com_ptr<ID3D11Device> m_d3dDevice;
+    winrt::com_ptr<ID3D11DeviceContext> m_d3dContext;
+
+    winrt::com_ptr<ID3D11VideoDevice> m_videoDevice;
+    winrt::com_ptr<ID3D11VideoContext> m_videoContext;
+    winrt::com_ptr<ID3D11VideoProcessor> m_videoProcessor;
+    winrt::com_ptr<ID3D11Texture2D> m_videoOutputTexture;
+    winrt::com_ptr<ID3D11VideoProcessorOutputView> m_videoOutput;
+    winrt::com_ptr<ID3D11Texture2D> m_videoInputTexture;
+    winrt::com_ptr<ID3D11VideoProcessorInputView> m_videoInput;
+};

--- a/ImageViewerNative/VideoFrameArgs.cpp
+++ b/ImageViewerNative/VideoFrameArgs.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "VideoFrameArgs.h"
+#include "VideoFrameArgs.g.cpp"
+
+namespace winrt::ImageViewerNative::implementation
+{
+    VideoFrameArgs::VideoFrameArgs(winrt::com_ptr<ID3D11Texture2D> const& texture)
+    {
+        m_surface = CreateDirect3DSurface(texture.as<IDXGISurface>().get());
+    }
+
+    void VideoFrameArgs::Reset(int64_t timestamp, uint64_t frameId)
+    {
+        m_timestamp = winrt::Windows::Foundation::TimeSpan{ timestamp };
+        m_frameId = frameId;
+    }
+}

--- a/ImageViewerNative/VideoFrameArgs.h
+++ b/ImageViewerNative/VideoFrameArgs.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "VideoFrameArgs.g.h"
+
+namespace winrt::ImageViewerNative::implementation
+{
+    struct VideoFrameArgs : VideoFrameArgsT<VideoFrameArgs>
+    {
+        VideoFrameArgs(winrt::com_ptr<ID3D11Texture2D> const& texture);
+
+        void Reset(int64_t timestamp, uint64_t frameId);
+
+        winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DSurface Surface() { return m_surface; }
+        winrt::Windows::Foundation::TimeSpan Timestamp() { return m_timestamp; }
+        uint64_t FrameId() { return m_frameId; }
+
+    private:
+        winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DSurface m_surface{ nullptr };
+        winrt::Windows::Foundation::TimeSpan m_timestamp = {};
+        uint64_t m_frameId = 0;
+    };
+}

--- a/ImageViewerNative/VideoFrameExtractor.cpp
+++ b/ImageViewerNative/VideoFrameExtractor.cpp
@@ -1,0 +1,131 @@
+#include "pch.h"
+#include "VideoFrameExtractor.h"
+#include "VideoFrameExtractor.g.cpp"
+#include "VideoFrameArgs.h"
+#include "VideoDecoderDevice.h"
+#include "VideoDecoder.h"
+#include "VideoDecoderProcessor.h"
+
+namespace winrt
+{
+    using namespace Windows::Foundation;
+    using namespace Windows::Graphics;
+}
+
+namespace winrt::ImageViewerNative::implementation
+{
+    void VideoFrameExtractor::ExtractFromStream(
+        winrt::Windows::Storage::Streams::IRandomAccessStream const& stream, 
+        winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DDevice const& device, 
+        winrt::Windows::Foundation::EventHandler<winrt::ImageViewerNative::VideoFrameArgs> const& callback)
+    {
+        auto d3dDevice = GetDXGIInterfaceFromObject<ID3D11Device>(device);
+
+        // Create our source and reader
+        winrt::com_ptr<IMFSourceResolver> sourceResolver;
+        winrt::check_hresult(MFCreateSourceResolver(sourceResolver.put()));
+
+        // IRandomAccessStream -> IStream -> IMFByteStream
+        auto streamUnknown = stream.as<::IUnknown>();
+        winrt::com_ptr<IStream> istream;
+        winrt::check_hresult(CreateStreamOverRandomAccessStream(streamUnknown.get(), winrt::guid_of<IStream>(), istream.put_void()));
+        winrt::com_ptr<IMFByteStream> mfByteStream;
+        winrt::check_hresult(MFCreateMFByteStreamOnStreamEx(istream.get(), mfByteStream.put()));
+
+        // Create our source resolver
+        winrt::com_ptr<IMFSourceReader> sourceReader;
+        winrt::check_hresult(MFCreateSourceReaderFromByteStream(mfByteStream.get(), nullptr, sourceReader.put()));
+        
+        // Configure our reader
+        winrt::check_hresult(sourceReader->SetStreamSelection(MF_SOURCE_READER_ALL_STREAMS, (DWORD)false));
+        winrt::check_hresult(sourceReader->SetStreamSelection((DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM, (DWORD)true));
+
+        winrt::com_ptr<IMFMediaType> inputType;
+        winrt::check_hresult(sourceReader->GetCurrentMediaType((DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM, inputType.put()));
+        GUID videoSubtype = {};
+        winrt::check_hresult(inputType->GetGUID(MF_MT_SUBTYPE, &videoSubtype));
+        uint32_t width = 0;
+        uint32_t height = 0;
+        winrt::check_hresult(MFGetAttributeSize(inputType.get(), MF_MT_FRAME_SIZE, &width, &height));
+        
+        winrt::SizeInt32 resolution{ static_cast<int32_t>(width), static_cast<int32_t>(height) };
+
+        // Setup our video decoder pipeline
+        auto videoProcessor = VideoDecoderProcessor(d3dDevice, DXGI_FORMAT_NV12, resolution, DXGI_FORMAT_B8G8R8A8_UNORM, resolution);
+        auto decoderDevices = VideoDecoderDevice::EnumerateAll(videoSubtype);
+        auto decoderDevice = decoderDevices[0];
+        auto videoDecoder = VideoDecoder(decoderDevice, d3dDevice, inputType);
+
+        // Get ready for output
+        uint32_t frameId = 0;
+        auto args = winrt::make_self<winrt::ImageViewerNative::implementation::VideoFrameArgs>(videoProcessor.OutputTexture());
+
+        // Start decoding
+        while (true)
+        {
+            DWORD streamIndex = 0;
+            DWORD flags = 0;
+            LONGLONG timeStamp = 0;
+            winrt::com_ptr<IMFSample> videoSample;
+            winrt::check_hresult(sourceReader->ReadSample(MF_SOURCE_READER_FIRST_VIDEO_STREAM, 0, &streamIndex, &flags, &timeStamp, videoSample.put()));
+
+            if (flags & MF_SOURCE_READERF_ENDOFSTREAM)
+            {
+                break;
+            }
+
+            assert(videoSample.get() != nullptr);
+
+            bool processedInput = true;
+            auto inputResult = videoDecoder.ProcessInputSample(videoSample);
+            if (inputResult == MF_E_NOTACCEPTING)
+            {
+                processedInput = false;
+            }
+            else
+            {
+                winrt::check_hresult(inputResult);
+            }
+
+            auto decodeResult = SampleProcessResult::NeedsMoreInput;
+            do
+            {
+                int64_t sampleTime = 0;
+                winrt::com_ptr<ID3D11Texture2D> frame;
+                decodeResult = videoDecoder.ProcessOutputSample(frame, sampleTime);
+
+                while (decodeResult == SampleProcessResult::StreamChanged)
+                {
+                    inputResult = videoDecoder.ProcessInputSample(videoSample);
+                    if (inputResult == MF_E_NOTACCEPTING)
+                    {
+                        processedInput = false;
+                    }
+                    else
+                    {
+                        winrt::check_hresult(inputResult);
+                    }
+                    decodeResult = videoDecoder.ProcessOutputSample(frame, sampleTime);
+                }
+
+                if (decodeResult == SampleProcessResult::Success)
+                {
+                    videoProcessor.ProcessTexture(frame, videoDecoder.OutputBox());
+                    auto& outputTexture = videoProcessor.OutputTexture();
+
+                    // Callback
+                    auto currentFrameId = frameId++;
+                    args->Reset(timeStamp, currentFrameId);
+                    callback(nullptr, args.as<winrt::ImageViewerNative::VideoFrameArgs>());
+                }
+
+            } while (decodeResult != SampleProcessResult::NeedsMoreInput);
+
+            if (!processedInput)
+            {
+                // Failing this means we drop the sample
+                winrt::check_hresult(videoDecoder.ProcessInputSample(videoSample));
+            }
+        }
+    }
+}

--- a/ImageViewerNative/VideoFrameExtractor.h
+++ b/ImageViewerNative/VideoFrameExtractor.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "VideoFrameExtractor.g.h"
+
+namespace winrt::ImageViewerNative::implementation
+{
+    struct VideoFrameExtractor
+    {
+        VideoFrameExtractor() = default;
+
+        static void ExtractFromStream(winrt::Windows::Storage::Streams::IRandomAccessStream const& stream, winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DDevice const& device, winrt::Windows::Foundation::EventHandler<winrt::ImageViewerNative::VideoFrameArgs> const& callback);
+    };
+}
+namespace winrt::ImageViewerNative::factory_implementation
+{
+    struct VideoFrameExtractor : VideoFrameExtractorT<VideoFrameExtractor, implementation::VideoFrameExtractor>
+    {
+    };
+}

--- a/ImageViewerNative/packages.config
+++ b/ImageViewerNative/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.220531.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.230824.2" targetFramework="native" />
+  <package id="robmikh.common" version="0.0.22-beta" targetFramework="native" />
+</packages>

--- a/ImageViewerNative/pch.cpp
+++ b/ImageViewerNative/pch.cpp
@@ -1,0 +1,1 @@
+﻿#include "pch.h"

--- a/ImageViewerNative/pch.h
+++ b/ImageViewerNative/pch.h
@@ -1,0 +1,50 @@
+﻿#pragma once
+
+// Windows SDK
+#include <unknwn.h>
+#include <inspectable.h>
+#include <Windows.h>
+#include <libloaderapi.h>
+
+// WinRT
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Graphics.h>
+#include <winrt/Windows.Graphics.DirectX.h>
+#include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
+#include <winrt/Windows.Storage.Streams.h>
+
+// WinRT Interop
+#include <robuffer.h>
+#include <shcore.h>
+
+// WIL
+#include <wil/resource.h>
+
+// DirectX
+#include <d3d11_4.h>
+#include <dxgi1_6.h>
+#include <d2d1_3.h>
+#include <wincodec.h>
+
+// Media Foundation
+#include <mfidl.h>
+#include <mfapi.h>
+#include <mfreadwrite.h>
+#include <mferror.h>
+#include <wmcodecdsp.h>
+#include <codecapi.h>
+
+// STL
+#include <vector>
+#include <string>
+#include <atomic>
+#include <memory>
+#include <algorithm>
+#include <mutex>
+#include <sstream>
+
+// robmikh.common
+#include <robmikh.common/d3dHelpers.h>
+#include <robmikh.common/direct3d11.interop.h>
+#include <robmikh.common/mfHelpers.h>


### PR DESCRIPTION
This introduces a new image type that opens each frame of a video. This currently requires a decent chunk of memory due to how the decode operation works. In the future it might be wise to give the user the ability to only view a given segment of the video.